### PR TITLE
ci: survive an expired build cache and report release failures to Slack

### DIFF
--- a/.github/workflows/fullRelease.yml
+++ b/.github/workflows/fullRelease.yml
@@ -194,3 +194,62 @@ jobs:
     permissions:
       contents: read
       actions: write
+  notifySlackOnFailure:
+    name: Notify Slack on failure
+    needs:
+      - resolveSource
+      - createWebinyJsBranch
+      - createDocsBranch
+    if: failure()
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LABEL: Full release of Webiny ${{ github.event.inputs.version }}
+      RUN_URL: >-
+        ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+        github.run_id }}
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - name: Notify Slack
+        run: >-
+          set -euo pipefail
+
+
+          [ -z "$SLACK_RELEASE_CHANNEL_WEBHOOK" ] && echo "Slack webhook not
+          configured, skipping." && exit 0
+
+
+          # Name the jobs that actually failed, so the message says something
+          without
+
+          # anyone having to open the run first.
+
+          FAILED=$(gh api --paginate "repos/${{ github.repository
+          }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+          [ -n "$FAILED" ] || FAILED="unknown job"
+
+
+          # Built with jq, not string interpolation: job names here contain
+          double quotes
+
+          # (`NPM release ("latest" tag)`) and would produce invalid JSON
+          otherwise.
+
+          jq -nc --arg label "$LABEL" --arg failed "$FAILED" --arg url
+          "$RUN_URL" \
+            '{ text: ":rotating_light: \($label) failed: \($failed)\n\($url)" }' \
+            > /tmp/slack-payload.json
+
+          curl -s -o /dev/null -X POST \
+            -H "Content-type: application/json" \
+            --data @/tmp/slack-payload.json \
+            "$SLACK_RELEASE_CHANNEL_WEBHOOK"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write

--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           name: run-build-cache
           path: run-build-cache.tzst
-          retention-days: 1
+          retention-days: 7
           compression-level: 0
           if-no-files-found: error
           overwrite: true
@@ -178,8 +178,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           name: run-build-cache
           path: run-build-cache.tzst
-          retention-days: 1
+          retention-days: 7
           compression-level: 0
           if-no-files-found: error
           overwrite: true
@@ -178,8 +178,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -271,8 +277,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -322,6 +334,66 @@ jobs:
           curl -s -o /dev/null -X POST \
             -H "Content-type: application/json" \
             --data "{\"text\":\"${MSG}\"}" \
+            "$SLACK_RELEASE_CHANNEL_WEBHOOK"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+  notifySlackOnFailure:
+    name: Notify Slack on failure
+    needs:
+      - prBranch
+      - build
+      - npmReleaseBeta
+      - npmReleaseLatest
+    if: failure()
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LABEL: Beta release (/beta)
+      RUN_URL: >-
+        ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+        github.run_id }}
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - name: Notify Slack
+        run: >-
+          set -euo pipefail
+
+
+          [ -z "$SLACK_RELEASE_CHANNEL_WEBHOOK" ] && echo "Slack webhook not
+          configured, skipping." && exit 0
+
+
+          # Name the jobs that actually failed, so the message says something
+          without
+
+          # anyone having to open the run first.
+
+          FAILED=$(gh api --paginate "repos/${{ github.repository
+          }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+          [ -n "$FAILED" ] || FAILED="unknown job"
+
+
+          # Built with jq, not string interpolation: job names here contain
+          double quotes
+
+          # (`NPM release ("latest" tag)`) and would produce invalid JSON
+          otherwise.
+
+          jq -nc --arg label "$LABEL" --arg failed "$FAILED" --arg url
+          "$RUN_URL" \
+            '{ text: ":rotating_light: \($label) failed: \($failed)\n\($url)" }' \
+            > /tmp/slack-payload.json
+
+          curl -s -o /dev/null -X POST \
+            -H "Content-type: application/json" \
+            --data @/tmp/slack-payload.json \
             "$SLACK_RELEASE_CHANNEL_WEBHOOK"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           name: run-build-cache
           path: run-build-cache.tzst
-          retention-days: 1
+          retention-days: 7
           compression-level: 0
           if-no-files-found: error
           overwrite: true
@@ -272,8 +272,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -522,8 +528,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -725,8 +737,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -934,8 +952,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           name: run-build-cache
           path: run-build-cache.tzst
-          retention-days: 1
+          retention-days: 7
           compression-level: 0
           if-no-files-found: error
           overwrite: true
@@ -335,8 +335,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -507,8 +513,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -689,8 +701,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -880,8 +898,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:
@@ -1054,8 +1078,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
+        continue-on-error: true
       - name: Extract build cache
         run: >-
+          if [ ! -f run-build-cache.tzst ]; then
+            echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."
+            exit 0
+          fi
+
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
           "${WEBINY_JS_DIR:-.}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,3 +198,63 @@ jobs:
     permissions:
       contents: read
       actions: write
+  notifySlackOnFailure:
+    name: Notify Slack on failure
+    needs:
+      - constants
+      - build
+      - npmReleaseBeta
+      - npmReleaseLatest
+    if: failure()
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LABEL: 📦 Release
+      RUN_URL: >-
+        ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+        github.run_id }}
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - name: Notify Slack
+        run: >-
+          set -euo pipefail
+
+
+          [ -z "$SLACK_RELEASE_CHANNEL_WEBHOOK" ] && echo "Slack webhook not
+          configured, skipping." && exit 0
+
+
+          # Name the jobs that actually failed, so the message says something
+          without
+
+          # anyone having to open the run first.
+
+          FAILED=$(gh api --paginate "repos/${{ github.repository
+          }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+          [ -n "$FAILED" ] || FAILED="unknown job"
+
+
+          # Built with jq, not string interpolation: job names here contain
+          double quotes
+
+          # (`NPM release ("latest" tag)`) and would produce invalid JSON
+          otherwise.
+
+          jq -nc --arg label "$LABEL" --arg failed "$FAILED" --arg url
+          "$RUN_URL" \
+            '{ text: ":rotating_light: \($label) failed: \($failed)\n\($url)" }' \
+            > /tmp/slack-payload.json
+
+          curl -s -o /dev/null -X POST \
+            -H "Content-type: application/json" \
+            --data @/tmp/slack-payload.json \
+            "$SLACK_RELEASE_CHANNEL_WEBHOOK"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write

--- a/.github/workflows/wac/fullRelease.wac.ts
+++ b/.github/workflows/wac/fullRelease.wac.ts
@@ -1,6 +1,6 @@
 import { ACTION } from "./utils/index.js";
 import { createWorkflow } from "github-actions-wac";
-import { createJob } from "./jobs/index.js";
+import { createJob, createSlackFailureJob } from "./jobs/index.js";
 
 const VERSION = "${{ github.event.inputs.version }}";
 
@@ -178,6 +178,10 @@ export const fullRelease = createWorkflow({
                     run: `gh workflow run create-release-branch.yml --repo webiny/docs.webiny.com -f version=${VERSION}`
                 }
             ]
+        }),
+        notifySlackOnFailure: createSlackFailureJob({
+            needs: ["resolveSource", "createWebinyJsBranch", "createDocsBranch"],
+            label: `Full release of Webiny ${VERSION}`
         })
     }
 });

--- a/.github/workflows/wac/jobs/createSlackFailureJob.ts
+++ b/.github/workflows/wac/jobs/createSlackFailureJob.ts
@@ -1,0 +1,64 @@
+import { NormalJob } from "github-actions-wac";
+import { createJob } from "./createJob.js";
+
+interface CreateSlackFailureJobParams {
+    // Every job that publishing depends on. `failure()` only fires when one of these failed, so a
+    // job left out here fails silently.
+    needs: string[];
+    // What to call the thing that broke, in the message. e.g. "Beta release".
+    label: string;
+}
+
+/**
+ * A last job that posts to the release Slack channel when a release breaks.
+ *
+ * Releases fail in the quietest possible way: a `/beta` comment gets its "release initiated"
+ * reply, the run goes green through the beta publish, and then the "latest" job sits behind a
+ * required reviewer for days before dying. Nobody is watching the Actions tab at that point. This
+ * makes the failure arrive where the release announcements already do.
+ *
+ * `if: failure()` deliberately excludes cancellations. `/beta` has `cancel-in-progress`, so a
+ * second `/beta` on the same PR cancels the first one - routine, and not worth a ping.
+ */
+export const createSlackFailureJob = (params: CreateSlackFailureJobParams): NormalJob => {
+    return createJob({
+        name: "Notify Slack on failure",
+        needs: params.needs,
+        if: "failure()",
+        checkout: false,
+        env: {
+            SLACK_RELEASE_CHANNEL_WEBHOOK: "${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}",
+            GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+            LABEL: params.label,
+            RUN_URL:
+                "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        },
+        steps: [
+            {
+                name: "Notify Slack",
+                run: [
+                    "set -euo pipefail",
+                    "",
+                    '[ -z "$SLACK_RELEASE_CHANNEL_WEBHOOK" ] && echo "Slack webhook not configured, skipping." && exit 0',
+                    "",
+                    "# Name the jobs that actually failed, so the message says something without",
+                    "# anyone having to open the run first.",
+                    'FAILED=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \\',
+                    '  --jq \'[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")\')',
+                    '[ -n "$FAILED" ] || FAILED="unknown job"',
+                    "",
+                    "# Built with jq, not string interpolation: job names here contain double quotes",
+                    '# (`NPM release ("latest" tag)`) and would produce invalid JSON otherwise.',
+                    'jq -nc --arg label "$LABEL" --arg failed "$FAILED" --arg url "$RUN_URL" \\',
+                    `  '{ text: ":rotating_light: \\($label) failed: \\($failed)\\n\\($url)" }' \\`,
+                    "  > /tmp/slack-payload.json",
+                    "",
+                    "curl -s -o /dev/null -X POST \\",
+                    '  -H "Content-type: application/json" \\',
+                    "  --data @/tmp/slack-payload.json \\",
+                    '  "$SLACK_RELEASE_CHANNEL_WEBHOOK"'
+                ].join("\n")
+            }
+        ]
+    });
+};

--- a/.github/workflows/wac/jobs/index.ts
+++ b/.github/workflows/wac/jobs/index.ts
@@ -1,3 +1,4 @@
 export * from "./createJob.js";
 export * from "./checkCommand.js";
 export * from "./createSlashCommandWorkflow.js";
+export * from "./createSlackFailureJob.js";

--- a/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
@@ -1,5 +1,5 @@
 import { BUILD_PACKAGES_RUNNER } from "./utils/index.js";
-import { createJob, createSlashCommandWorkflow } from "./jobs/index.js";
+import { createJob, createSlackFailureJob, createSlashCommandWorkflow } from "./jobs/index.js";
 import {
     createInstallBuildSteps,
     createRunBuildArtifactDownloadSteps,
@@ -213,6 +213,10 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                     ].join("\n")
                 }
             ]
+        }),
+        notifySlackOnFailure: createSlackFailureJob({
+            needs: ["prBranch", "build", "npmReleaseBeta", "npmReleaseLatest"],
+            label: "Beta release (/beta)"
         })
     }
 });

--- a/.github/workflows/wac/release.wac.ts
+++ b/.github/workflows/wac/release.wac.ts
@@ -1,6 +1,6 @@
 import { createWorkflow } from "github-actions-wac";
 import { BUILD_PACKAGES_RUNNER } from "./utils";
-import { createJob } from "./jobs";
+import { createJob, createSlackFailureJob } from "./jobs";
 import {
     createGlobalBuildCacheSteps,
     createInstallBuildSteps,
@@ -146,6 +146,10 @@ export const release = createWorkflow({
                     { "working-directory": BRANCH_NAME }
                 )
             ]
+        }),
+        notifySlackOnFailure: createSlackFailureJob({
+            needs: ["constants", "build", "npmReleaseBeta", "npmReleaseLatest"],
+            label: "📦 Release"
         })
     }
 });

--- a/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
@@ -55,7 +55,13 @@ export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifact
             with: {
                 name: ARTIFACT_NAME,
                 path: ARCHIVE,
-                "retention-days": 1,
+                // A day was enough while every consumer ran minutes after the build. It is not
+                // enough for `/beta`, whose "latest" job sits behind a required reviewer on the
+                // `release` environment: one release waited 3 days 22 hours for approval and then
+                // failed on an artifact that had expired 3 days earlier. The download is no longer
+                // fatal (see below), but a week of retention keeps the fast path working for any
+                // realistic approval delay. The tarball is ~10 MB per run.
+                "retention-days": 7,
                 // The tarball is already zstd-compressed; re-deflating it only burns CPU.
                 "compression-level": 0,
                 "if-no-files-found": "error",
@@ -65,16 +71,28 @@ export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifact
     ] as const;
 };
 
+// The artifact is a CACHE, not an input: every consumer job runs `yarn install` and `yarn build`
+// after extracting it, and `.webiny/cached-packages` only makes that build fast. So a missing
+// artifact has to mean a slower job, never a failed one - which is what `continue-on-error` plus
+// the guard in the extract step buy. No retention number can be trusted on its own here, because
+// a job waiting on a required reviewer can outlive any of them.
 export const createRunBuildArtifactDownloadSteps = (params: CreateRunBuildArtifactStepsParams) => {
     return [
         {
             name: "Download build cache",
             uses: ACTION.downloadArtifact,
-            with: { name: ARTIFACT_NAME }
+            with: { name: ARTIFACT_NAME },
+            "continue-on-error": true
         },
         {
             name: "Extract build cache",
-            run: `tar -xf ${ARCHIVE} --use-compress-program=zstdmt -C ${TARGET_DIR}`,
+            run: [
+                `if [ ! -f ${ARCHIVE} ]; then`,
+                `  echo "::warning::No build cache artifact - building from scratch. This job will be slower than usual."`,
+                "  exit 0",
+                "fi",
+                `tar -xf ${ARCHIVE} --use-compress-program=zstdmt -C ${TARGET_DIR}`
+            ].join("\n"),
             env: { WEBINY_JS_DIR: params.workingDirectory }
         }
     ] as const;


### PR DESCRIPTION
### What changed

Two fixes for the same incident: [Release 6.4.10](https://github.com/webiny/webiny-js/pull/5624) died at `Download build cache` with `Artifact not found for name: run-build-cache`, and nobody found out until someone happened to look.

### Why it failed

| | |
| --- | --- |
| Build uploads `run-build-cache` | 2026-09-03 12:02:07 |
| Artifact expires (`retention-days: 1`) | 2026-09-04 12:02:05 |
| `NPM release ("latest" tag)` starts | 2026-09-07 10:45:44 |

The `release` environment has `required_reviewers`, so that job waited 3 days 22 hours for approval while its input expired underneath it. The API still lists the artifact with `expired: true`.

### Fix 1: a missing artifact should not kill a release

The artifact is a cache, not an input. Every consumer job runs `Install dependencies` and `Build packages` right after extracting it, and `.webiny/cached-packages` only makes that build fast.

- `Download build cache` is now `continue-on-error: true`.
- `Extract build cache` skips with a warning when the tarball is not there.
- `retention-days` goes from 1 to 7.

The retention bump alone would have fixed this particular release, but it is not the real fix. No retention number can be trusted when a job can wait on a human indefinitely, so the download had to stop being fatal. Retention still matters for the fast path: without the artifact the job rebuilds from scratch, which is slower, and a week covers any realistic approval delay. The tarball is ~10 MB per run.

This touches `/alpha`, `/e2e` and `/vitest` too, since they share the same download steps. Same reasoning applies to all of them.

### Fix 2: say something when a release breaks

Releases fail in the quietest way available. The `/beta` comment gets its "release initiated" reply, the run goes green through the beta publish, and the actual failure lands days later behind an approval gate that nobody is watching.

A final `notifySlackOnFailure` job now posts to `SLACK_RELEASE_CHANNEL_WEBHOOK` (the channel that already gets the release announcements) in three workflows:

- `💬 PR Command - Beta Release`
- `📦 Release`
- `🚀 Full Release`

It names the jobs that actually failed and links the run, so the message is useful without opening anything:

```
🚨 Beta release (/beta) failed: NPM release ("latest" tag)
https://github.com/webiny/webiny-js/actions/runs/33752389240
```

Two details worth flagging:

- **`if: failure()` deliberately excludes cancellations.** `/beta` has `cancel-in-progress`, so a second `/beta` on the same PR cancels the first. That happened twice on 6.4.10 and is routine, not worth a ping.
- **The payload is built with `jq`, not string interpolation.** Job names here contain double quotes (`NPM release ("latest" tag)`), which would produce invalid JSON the way the existing Slack steps build theirs. Verified against exactly that job name.

`/alpha` and the unstable release are not wired up. Both are one line each if you want them.

### Changelog

**Title line:** More reliable release pipeline

**Body:** A release no longer fails when its cached build output has expired, and failures now get announced in Slack instead of going unnoticed. This is a CI change with no effect on Webiny itself.

### Squash Merge Commit

```
ci: survive an expired build cache and report release failures (#5666)
fix(ci): stop an expired build cache artifact from failing releases (#5666)
```
