### PR TITLE
fix: merge release/6.4.10 fixes into release/6.5.0

### DIFF
--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -45,10 +45,13 @@ const setupAcoContext = async (context: AcoContext): Promise<void> => {
 
     const getModel = container.resolve(GetModelUseCase);
 
-    await security.withoutAuthorization(async () => {
-        const folderModel = await getModel.execute(FOLDER_MODEL_ID);
-        container.registerInstance(FolderModelAbstraction, folderModel.value);
+    const folderModelResult = await security.withoutAuthorization(async () => {
+        return await getModel.execute(FOLDER_MODEL_ID);
     });
+    if (folderModelResult.isFail()) {
+        throw folderModelResult.error;
+    }
+    container.registerInstance(FolderModelAbstraction, folderModelResult.value);
 
     const getTenant = (): Tenant => {
         return tenancy.getCurrentTenant();

--- a/packages/api-aco/src/features/folder/EnsureFolderIsEmpty/EnsureFolderIsEmpty.ts
+++ b/packages/api-aco/src/features/folder/EnsureFolderIsEmpty/EnsureFolderIsEmpty.ts
@@ -1,6 +1,7 @@
 import { FolderLevelPermissions } from "~/features/flp/FolderLevelPermissions/index.js";
 import { ListFoldersUseCase } from "~/features/folder/ListFolders/index.js";
 import { EnsureFolderIsEmpty as Abstraction } from "~/features/folder/EnsureFolderIsEmpty/abstractions.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
 import { FolderNotAuthorizedError, FolderNotEmptyError } from "~/domain/folder/errors.js";
 import { Result } from "@webiny/feature/api";
@@ -9,7 +10,8 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
     constructor(
         private identityContext: IdentityContext.Interface,
         private folderLevelPermissions: FolderLevelPermissions.Interface,
-        private listFoldersUseCase: ListFoldersUseCase.Interface
+        private listFoldersUseCase: ListFoldersUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async execute(
@@ -25,9 +27,9 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
                 },
                 limit: 1
             });
-
             if (result.isFail()) {
-                console.error(result.error.message);
+                this.logger.error(result.error);
+                // Report the folder as non-empty so a failed lookup cannot green-light a delete.
                 return true;
             }
 
@@ -73,5 +75,5 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
 
 export const EnsureFolderIsEmpty = Abstraction.createImplementation({
     implementation: EnsureFolderIsEmptyImpl,
-    dependencies: [IdentityContext, FolderLevelPermissions, ListFoldersUseCase]
+    dependencies: [IdentityContext, FolderLevelPermissions, ListFoldersUseCase, Logger]
 });

--- a/packages/api-core/src/features/security/roles/Installer/RolesInstaller.ts
+++ b/packages/api-core/src/features/security/roles/Installer/RolesInstaller.ts
@@ -19,6 +19,9 @@ class RolesInstallerImpl implements AppInstaller.Interface {
 
     async install(): Promise<void> {
         const rolesResult = await this.listRolesUseCase.execute();
+        if (rolesResult.isFail()) {
+            throw rolesResult.error;
+        }
         const roles = rolesResult.value;
 
         if (!roles.find(g => g.slug === "full-access")) {

--- a/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
@@ -30,6 +30,9 @@ class CreateIndexesTaskRunnerImpl implements Abstraction.Interface {
         }
 
         const tenantsResult = await this.listTenantsUseCase.execute();
+        if (tenantsResult.isFail()) {
+            return this.taskController.response.error(tenantsResult.error);
+        }
         const tenants = tenantsResult.value;
 
         const indexes = await listIndexes(this.tenantContext, tenants, this.indexFactories);

--- a/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
@@ -31,7 +31,7 @@ class CreateIndexesTaskRunnerImpl implements Abstraction.Interface {
 
         const tenantsResult = await this.listTenantsUseCase.execute();
         if (tenantsResult.isFail()) {
-            return this.taskController.response.error(tenantsResult.error);
+            return this.controller.response.error(tenantsResult.error);
         }
         const tenants = tenantsResult.value;
 

--- a/packages/api-file-manager-aco/src/features/EnsureFolderIsEmptyBeforeDelete/EnsureFolderIsEmptyBeforeDelete.ts
+++ b/packages/api-file-manager-aco/src/features/EnsureFolderIsEmptyBeforeDelete/EnsureFolderIsEmptyBeforeDelete.ts
@@ -31,6 +31,10 @@ class EnsureFolderIsEmptyBeforeDeleteImpl implements FolderBeforeDeleteEventHand
                 limit: 1
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { items } = result.value;
 
             return items.length > 0;

--- a/packages/api-file-manager/src/features/settings/UpdateSettings/UpdateSettingsUseCase.ts
+++ b/packages/api-file-manager/src/features/settings/UpdateSettings/UpdateSettingsUseCase.ts
@@ -33,6 +33,9 @@ class UpdateSettingsUseCaseImpl implements UseCaseAbstraction.Interface {
 
         // Get existing settings to merge with new data
         const existingResult = await this.getSettings.execute();
+        if (existingResult.isFail()) {
+            return existingResult;
+        }
         const existing = existingResult.value;
 
         // Prepare merged settings

--- a/packages/api-file-manager/src/graphql/FmGraphQLSchema.ts
+++ b/packages/api-file-manager/src/graphql/FmGraphQLSchema.ts
@@ -520,6 +520,10 @@ class FmGraphQLSchemaImpl implements GraphQLSchemaFactory.Interface {
             return this.listModelsUseCase.execute();
         });
 
+        if (modelsResult.isFail()) {
+            throw modelsResult.error;
+        }
+
         return modelsResult.value;
     }
 }

--- a/packages/api-file-manager/src/graphql/FmUploadGraphQLSchema.ts
+++ b/packages/api-file-manager/src/graphql/FmUploadGraphQLSchema.ts
@@ -127,6 +127,9 @@ class FmUploadGraphQLSchema_ implements GraphQLSchemaFactory.Interface {
 
                         const data = args.data as PresignedPostPayloadData;
                         const settingsResult = await getSettings.execute();
+                        if (settingsResult.isFail()) {
+                            throw settingsResult.error;
+                        }
                         const settings = settingsResult.value;
 
                         const normalizer = createFileNormalizerFromContext(context);
@@ -159,6 +162,9 @@ class FmUploadGraphQLSchema_ implements GraphQLSchemaFactory.Interface {
 
                         const files = args.data as PresignedPostPayloadData[];
                         const settingsResult = await getSettings.execute();
+                        if (settingsResult.isFail()) {
+                            throw settingsResult.error;
+                        }
                         const settings = settingsResult.value;
 
                         const normalizer = createFileNormalizerFromContext(context);

--- a/packages/api-file-manager/src/index.ts
+++ b/packages/api-file-manager/src/index.ts
@@ -30,6 +30,9 @@ export const createFileManagerContext = () => {
 
         await context.security.withoutAuthorization(async () => {
             const fileModel = await getModel.execute(FILE_MODEL_ID);
+            if (fileModel.isFail()) {
+                throw fileModel.error;
+            }
             container.registerInstance(FileModelAbstraction, fileModel.value);
         });
     });

--- a/packages/api-headless-cms-bulk-actions/src/features/DeleteEntriesBulkAction/DeleteEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/DeleteEntriesBulkAction/DeleteEntriesBulkAction.ts
@@ -16,6 +16,9 @@ class DeleteEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listDeletedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/MoveToFolderBulkAction/MoveToFolderBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/MoveToFolderBulkAction/MoveToFolderBulkAction.ts
@@ -15,6 +15,9 @@ class MoveToFolderBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listLatestEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/MoveToTrashBulkAction/MoveToTrashBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/MoveToTrashBulkAction/MoveToTrashBulkAction.ts
@@ -16,6 +16,9 @@ class MoveToTrashBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listLatestEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/PublishEntriesBulkAction/PublishEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/PublishEntriesBulkAction/PublishEntriesBulkAction.ts
@@ -24,6 +24,10 @@ class PublishEntriesBulkActionImpl implements EntriesBulkAction.Interface {
             }
         });
 
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
+
         return entriesResult.value;
     }
 

--- a/packages/api-headless-cms-bulk-actions/src/features/RestoreEntriesBulkAction/RestoreEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/RestoreEntriesBulkAction/RestoreEntriesBulkAction.ts
@@ -16,6 +16,9 @@ class RestoreEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listDeletedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/UnpublishEntriesBulkAction/UnpublishEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/UnpublishEntriesBulkAction/UnpublishEntriesBulkAction.ts
@@ -15,6 +15,9 @@ class UnpublishEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listPublishedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
@@ -57,6 +57,9 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
 
         // Fetch all tenants, excluding those already processed.
         const tenantsResult = await this.listTenants.execute();
+        if (tenantsResult.isFail()) {
+            return controller.response.error(tenantsResult.error);
+        }
         const baseTenants = tenantsResult.value;
         const executedTenantIds = input.executedTenantIds || [];
         const tenants = baseTenants.filter(tenant => !executedTenantIds.includes(tenant.id));
@@ -77,6 +80,10 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
 
             // List all non-private models.
             const modelsResult = await this.listModels.execute({ includePrivate: false });
+            if (modelsResult.isFail()) {
+                controller.logger.error(modelsResult.error);
+                return;
+            }
             const models = modelsResult.value;
 
             // Process each model to delete trashed entries.
@@ -95,6 +102,10 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
                         model,
                         listEntriesParams
                     );
+                    if (listResult.isFail()) {
+                        controller.logger.error(listResult.error);
+                        break;
+                    }
                     const { entries, meta } = listResult.value;
 
                     if (meta.totalCount === 0) {

--- a/packages/api-headless-cms-ddb-es/src/tasks/CreateElasticsearchIndexTask.ts
+++ b/packages/api-headless-cms-ddb-es/src/tasks/CreateElasticsearchIndexTask.ts
@@ -3,15 +3,21 @@ import type { Tenant } from "@webiny/api-core/types/tenancy.js";
 import { ListModelsUseCase } from "@webiny/api-headless-cms/features/contentModel/ListModels/index.js";
 import { CmsModelOpenSearchIndexProvider } from "~/features/CmsModelOpenSearchIndex/index.js";
 import { getOpenSearchIndexPrefix } from "@webiny/api-opensearch";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 
 class CreateElasticsearchIndexTaskImpl implements OpenSearchTenantIndexFactory.Interface {
     constructor(
         private readonly indexProvider: CmsModelOpenSearchIndexProvider.Interface,
-        private listModels: ListModelsUseCase.Interface
+        private listModels: ListModelsUseCase.Interface,
+        private readonly logger: Logger.Interface
     ) {}
 
     async getIndexList(tenant: Tenant): Promise<OpenSearchTenantIndexFactory.IndexConfig[]> {
         const result = await this.listModels.execute();
+        if (result.isFail()) {
+            this.logger.error(result.error);
+            return [];
+        }
         const models = result.value;
 
         if (models.length === 0) {
@@ -41,5 +47,5 @@ class CreateElasticsearchIndexTaskImpl implements OpenSearchTenantIndexFactory.I
 
 export const CreateElasticsearchIndexTask = OpenSearchTenantIndexFactory.createImplementation({
     implementation: CreateElasticsearchIndexTaskImpl,
-    dependencies: [CmsModelOpenSearchIndexProvider, ListModelsUseCase]
+    dependencies: [CmsModelOpenSearchIndexProvider, ListModelsUseCase, Logger]
 });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnEntryDeleteEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnEntryDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -17,7 +18,8 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterDeleteEventHandler.Event): Promise<void> {
@@ -47,6 +49,11 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return [];
+        }
+
         return actionsResult.value.items;
     }
 }
@@ -54,5 +61,5 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
 export const CancelScheduledActionOnEntryDeleteEventHandler =
     EntryAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnEntryDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnPublishEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnPublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypePublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -18,7 +19,8 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterPublishEventHandler.Event): Promise<void> {
@@ -37,6 +39,11 @@ class CancelScheduledActionOnPublishEventHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -52,5 +59,5 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 export const CancelScheduledActionOnPublishEventHandler =
     EntryAfterPublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPublishEventHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnRevisionDeleteEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnRevisionDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -15,7 +16,8 @@ import { createNamespace } from "~/utils/namespace.js";
 class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventHandler.Interface {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterDeleteEventHandler.Event): Promise<void> {
@@ -33,6 +35,11 @@ class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventH
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -48,5 +55,5 @@ class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventH
 export const CancelScheduledActionOnRevisionDeleteEventHandler =
     EntryAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnUnpublishEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnUnpublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypeUnpublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -18,7 +19,8 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterUnpublishEventHandler.Event): Promise<void> {
@@ -37,6 +39,11 @@ class CancelScheduledActionOnUnpublishHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -52,5 +59,5 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 export const CancelScheduledActionOnUnpublishEventHandler =
     EntryAfterUnpublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnUnpublishHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModel.ts
+++ b/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModel.ts
@@ -107,6 +107,10 @@ export class DeleteModel implements IDeleteModel {
                 limit: 1000
             });
 
+            if (listResult.isFail()) {
+                return controller.response.error(listResult.error);
+            }
+
             const { folders, meta } = listResult.value;
 
             for (const item of folders) {

--- a/packages/api-headless-cms-workflows/src/features/EntryWorkflows/handlers/DeleteWorkflowsOnModelAfterDelete.ts
+++ b/packages/api-headless-cms-workflows/src/features/EntryWorkflows/handlers/DeleteWorkflowsOnModelAfterDelete.ts
@@ -25,6 +25,10 @@ class DeleteWorkflowsOnModelAfterDeleteImpl implements ModelAfterDeleteEventHand
             limit: 10000
         });
 
+        if (result.isFail()) {
+            return;
+        }
+
         const workflows = result.value.items;
 
         for (const workflow of workflows) {

--- a/packages/api-headless-cms/__tests__/converters/dynamicZone/dynamicZone.unknownTemplate.test.ts
+++ b/packages/api-headless-cms/__tests__/converters/dynamicZone/dynamicZone.unknownTemplate.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createModel } from "../mocks/model.js";
+import { createModelField } from "../mocks/field.js";
+import { getConverters, type IConvertersResponse } from "../__helpers/converters.js";
+
+const model = createModel({
+    fields: [
+        createModelField({
+            fieldId: "content",
+            type: "dynamicZone",
+            list: true,
+            settings: {
+                templates: [
+                    {
+                        id: "textTemplate",
+                        name: "Text Template",
+                        gqlTypeName: "TextTemplate",
+                        icon: undefined,
+                        description: "",
+                        fields: [
+                            createModelField({
+                                fieldId: "title",
+                                type: "text",
+                                list: false
+                            })
+                        ],
+                        layout: [],
+                        validation: []
+                    }
+                ]
+            }
+        })
+    ]
+});
+
+describe("dynamicZone storage converter - unknown template handling", () => {
+    let converters: IConvertersResponse;
+
+    beforeEach(async () => {
+        converters = await getConverters(model);
+    });
+
+    it("should not include undefined entries when a list item references an unknown template", () => {
+        const { convertFromStorage } = converters;
+
+        const storageValue = {
+            "dynamicZone@contentId": [
+                {
+                    _templateId: "textTemplate",
+                    "text@titleId": "Hello"
+                },
+                {
+                    _templateId: "deletedTemplate",
+                    "text@titleId": "This template no longer exists"
+                },
+                {
+                    _templateId: "textTemplate",
+                    "text@titleId": "World"
+                }
+            ]
+        };
+
+        const result = convertFromStorage({
+            fields: model.fields,
+            values: storageValue
+        });
+
+        const items = result.content;
+        expect(Array.isArray(items)).toBe(true);
+        // The unknown template entry should be filtered out, not left as undefined
+        expect(items).not.toContainEqual(undefined);
+        expect(items).toHaveLength(2);
+        expect(items[0]).toEqual({ _templateId: "textTemplate", title: "Hello" });
+        expect(items[1]).toEqual({ _templateId: "textTemplate", title: "World" });
+    });
+
+    it("should return undefined for a single-value field referencing an unknown template", () => {
+        const singleModel = createModel({
+            fields: [
+                createModelField({
+                    fieldId: "content",
+                    type: "dynamicZone",
+                    list: false,
+                    settings: {
+                        templates: [
+                            {
+                                id: "textTemplate",
+                                name: "Text Template",
+                                gqlTypeName: "TextTemplate",
+                                icon: undefined,
+                                description: "",
+                                fields: [
+                                    createModelField({
+                                        fieldId: "title",
+                                        type: "text",
+                                        list: false
+                                    })
+                                ],
+                                layout: [],
+                                validation: []
+                            }
+                        ]
+                    }
+                })
+            ]
+        });
+
+        const run = async () => {
+            const singleConverters = await getConverters(singleModel);
+            return singleConverters.convertFromStorage({
+                fields: singleModel.fields,
+                values: {
+                    "dynamicZone@contentId": {
+                        _templateId: "deletedTemplate",
+                        "text@titleId": "Gone"
+                    }
+                }
+            });
+        };
+
+        expect(run()).resolves.toEqual({ content: undefined });
+    });
+});

--- a/packages/api-headless-cms/src/features/graphql/fields/base/RefToGraphQL.ts
+++ b/packages/api-headless-cms/src/features/graphql/fields/base/RefToGraphQL.ts
@@ -15,6 +15,7 @@ import { createGraphQLInputField } from "./utils/createGraphQLInputField.js";
 import { GetModelUseCase } from "~/features/contentModel/GetModel/index.js";
 import { GetPublishedEntriesByIdsUseCase } from "~/features/contentEntry/GetPublishedEntriesByIds/index.js";
 import { GetLatestEntriesByIdsUseCase } from "~/features/contentEntry/GetLatestEntriesByIds/index.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 
 interface RefFieldValue {
     /**
@@ -150,6 +151,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
             const getModel = container.resolve(GetModelUseCase);
             const getPublishedByIds = container.resolve(GetPublishedEntriesByIdsUseCase);
             const getLatestByIds = container.resolve(GetLatestEntriesByIdsUseCase);
+            const logger = container.resolve(Logger);
 
             const initialValue = getValue(parent);
 
@@ -169,7 +171,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
                     return [];
                 }
 
-                const entriesByModel = referenceFieldValues.reduce(
+                const entriesByModel = referenceFieldValues.reduce<Record<string, string[]>>(
                     (collection, ref) => {
                         if (!collection[ref.modelId]) {
                             collection[ref.modelId] = [];
@@ -179,21 +181,29 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
                         collection[ref.modelId].push(ref.entryId);
                         return collection;
                     },
-                    {} as Record<string, string[]>
+                    {}
                 );
 
                 const getters = Object.keys(entriesByModel).map(async modelId => {
                     const idList = entriesByModel[modelId];
                     const modelResult = await getModel.execute(modelId);
+                    if (modelResult.isFail()) {
+                        logger.error(modelResult.error);
+                        return [];
+                    }
                     const model = modelResult.value;
 
-                    let entries: CmsEntry[];
+                    let entries: CmsEntry[] = [];
                     if (cms.READ) {
                         const getPublishedResult = await getPublishedByIds.execute(model, idList);
-                        entries = getPublishedResult.value;
+                        if (getPublishedResult.isOk()) {
+                            entries = getPublishedResult.value;
+                        }
                     } else {
-                        const latestByIsResult = await getLatestByIds.execute(model, idList);
-                        entries = latestByIsResult.value;
+                        const latestByIdsResult = await getLatestByIds.execute(model, idList);
+                        if (latestByIdsResult.isOk()) {
+                            entries = latestByIdsResult.value;
+                        }
                     }
                     return appendTypename(entries, modelIdToTypeName.get(modelId)!);
                 });
@@ -213,17 +223,25 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
 
             const value = initialValue as RefFieldValue;
             const modelResult = await getModel.execute(value.modelId);
+            if (modelResult.isFail()) {
+                logger.error(modelResult.error);
+                return null;
+            }
             const model = modelResult.value;
 
-            let revisions: CmsEntry[];
+            let revisions: CmsEntry[] = [];
             if (cms.READ) {
                 const publishedByIdsResult = await getPublishedByIds.execute(model, [
                     value.entryId
                 ]);
-                revisions = publishedByIdsResult.value;
+                if (publishedByIdsResult.isOk()) {
+                    revisions = publishedByIdsResult.value;
+                }
             } else {
                 const latestByIdsResult = await getLatestByIds.execute(model, [value.entryId]);
-                revisions = latestByIdsResult.value;
+                if (latestByIdsResult.isOk()) {
+                    revisions = latestByIdsResult.value;
+                }
             }
 
             if (!revisions || revisions.length === 0) {

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -120,13 +120,15 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
             const arrayValue = Array.isArray(value) ? value : [];
 
             return {
-                [field.fieldId]: arrayValue.map(item => {
-                    return this.processFromStorage({
-                        templates,
-                        converterCollection,
-                        value: item
-                    });
-                })
+                [field.fieldId]: arrayValue
+                    .map(item => {
+                        return this.processFromStorage({
+                            templates,
+                            converterCollection,
+                            value: item
+                        });
+                    })
+                    .filter(Boolean)
             };
         }
 
@@ -162,13 +164,15 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
 
         const template = templates.find(t => t.id === _templateId);
         if (!template) {
-            throw new WebinyError(
-                "Unknown template - converting from storage.",
-                "UNKNOWN_TEMPLATE",
-                {
+            // TODO Should we just return undefined?
+            console.warn({
+                message: "Unknown template - converting from storage.",
+                code: "UNKNOWN_TEMPLATE",
+                data: {
                     templateId: _templateId
                 }
-            );
+            });
+            return undefined;
         }
 
         return template.fields.reduce<GenericRecord<string>>(

--- a/packages/api-mailer/src/graphql/settings.ts
+++ b/packages/api-mailer/src/graphql/settings.ts
@@ -85,6 +85,10 @@ export const createSettingsGraphQL = () => {
                         const getSettings = context.container.resolve(GetSettingsUseCase);
                         const result = await getSettings.execute(SMTP_TRANSPORT_NAME);
 
+                        if (result.isFail()) {
+                            return new ErrorResponse(result.error);
+                        }
+
                         const { settings, source } = result.value;
 
                         return {

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageDeleteEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -17,7 +18,8 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterDeleteEventHandler.Event): Promise<void> {
@@ -30,6 +32,11 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -46,5 +53,5 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
 export const CancelScheduledActionOnPageDeleteEventHandler =
     PageAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPageDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPagePublishEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPagePublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypePublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -19,7 +20,8 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterPublishEventHandler.Event): Promise<void> {
@@ -32,6 +34,11 @@ class CancelScheduledActionOnPublishEventHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -48,5 +55,5 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 export const CancelScheduledActionOnPagePublishEventHandler =
     PageAfterPublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPublishEventHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageUnpublishEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageUnpublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypeUnpublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -19,7 +20,8 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterUnpublishEventHandler.Event): Promise<void> {
@@ -32,6 +34,11 @@ class CancelScheduledActionOnUnpublishHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -48,5 +55,5 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 export const CancelScheduledActionOnPageUnpublishEventHandler =
     PageAfterUnpublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnUnpublishHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnRedirectDeleteEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnRedirectDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_REDIRECT } from "~/constants.js";
 
@@ -18,7 +19,8 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: RedirectAfterDeleteEventHandler.Event): Promise<void> {
@@ -30,6 +32,11 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
                 targetId: redirect.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -46,5 +53,5 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
 export const CancelScheduledActionOnRedirectDeleteEventHandler =
     RedirectAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnRedirectDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder/src/features/folders/EnsureWbPageFolderIsEmptyOnDelete/EnsureWbPageFolderIsEmptyOnDelete.ts
+++ b/packages/api-website-builder/src/features/folders/EnsureWbPageFolderIsEmptyOnDelete/EnsureWbPageFolderIsEmptyOnDelete.ts
@@ -30,6 +30,10 @@ class EnsureWbPageFolderIsEmptyOnDeleteImpl implements FolderBeforeDeleteEventHa
                 after: null
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { pages } = result.value;
 
             return pages.length > 0;

--- a/packages/api-website-builder/src/features/folders/EnsureWbRedirectFolderIsEmptyOnDelete/EnsureWbRedirectFolderIsEmptyOnDelete.ts
+++ b/packages/api-website-builder/src/features/folders/EnsureWbRedirectFolderIsEmptyOnDelete/EnsureWbRedirectFolderIsEmptyOnDelete.ts
@@ -30,6 +30,10 @@ class EnsureWbRedirectFolderIsEmptyOnDeleteImpl
                 limit: 1
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { redirects } = result.value;
 
             return redirects.length > 0;

--- a/packages/api-website-builder/src/rest/getRedirects.ts
+++ b/packages/api-website-builder/src/rest/getRedirects.ts
@@ -21,6 +21,9 @@ export const createRedirectsRoute = () => {
             const getActiveRedirects = context.container.resolve(GetActiveRedirectsUseCase);
 
             const result = await getActiveRedirects.execute();
+            if (result.isFail()) {
+                return reply.code(500).send(result.error);
+            }
 
             const redirectsDto = result.value.map(entry => ActiveRedirectRestMapper.toDto(entry));
 

--- a/packages/api-workflows/src/features/workflowState/CreateWorkflowState/CreateWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/CreateWorkflowState/CreateWorkflowStateUseCase.ts
@@ -131,6 +131,9 @@ class CreateWorkflowStateUseCaseImpl implements UseCase.Interface {
         const createdRecord = createResult.value;
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const workflowState = new WorkflowState(createdRecord, teams, identity);
 

--- a/packages/api-workflows/src/features/workflowState/DeleteTargetWorkflowState/DeleteTargetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/DeleteTargetWorkflowState/DeleteTargetWorkflowStateUseCase.ts
@@ -49,6 +49,9 @@ class DeleteTargetWorkflowStateUseCaseImpl implements UseCase.Interface {
 
         const identity = this.identityContext.getIdentity();
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const state = new WorkflowState(record, teams, identity);
 

--- a/packages/api-workflows/src/features/workflowState/GetTargetWorkflowState/GetTargetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/GetTargetWorkflowState/GetTargetWorkflowStateUseCase.ts
@@ -37,6 +37,9 @@ class GetTargetWorkflowStateUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const workflowState = new WorkflowState(record, teams, identity);

--- a/packages/api-workflows/src/features/workflowState/GetWorkflowState/GetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/GetWorkflowState/GetWorkflowStateUseCase.ts
@@ -23,6 +23,9 @@ class GetWorkflowStateUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const workflowState = new WorkflowState(record, teams, identity);

--- a/packages/api-workflows/src/features/workflowState/ListWorkflowStates/ListWorkflowStatesUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/ListWorkflowStates/ListWorkflowStatesUseCase.ts
@@ -20,6 +20,9 @@ class ListWorkflowStatesUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const requestedLimit = params.limit || 50;

--- a/packages/api-workflows/src/features/workflowState/UpdateWorkflowState/UpdateWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/UpdateWorkflowState/UpdateWorkflowStateUseCase.ts
@@ -53,6 +53,9 @@ class UpdateWorkflowStateUseCaseImpl implements UseCase.Interface {
 
         const identity = this.identityContext.getIdentity();
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const updatedState = new WorkflowState(updatedRecord, teams, identity);
 

--- a/packages/background-tasks/src/api/graphql/index.ts
+++ b/packages/background-tasks/src/api/graphql/index.ts
@@ -42,11 +42,13 @@ const createGraphQL = () => {
         const listModels = ctx.container.resolve(ListModelsUseCase);
         const fieldRegistry = ctx.container.resolve(CmsModelFieldToGraphQLRegistry);
 
-        const models = await ctx.security.withoutAuthorization(async () => {
-            const modelsResult = await listModels.execute({ includePrivate: false });
-
-            return modelsResult.value.filter(model => model.fields.length > 0);
+        const modelsResult = await ctx.security.withoutAuthorization(async () => {
+            return await listModels.execute({ includePrivate: false });
         });
+        if (modelsResult.isFail()) {
+            throw modelsResult.error;
+        }
+        const models = modelsResult.value.filter(model => model.fields.length > 0);
         const taskFields = renderFields({
             models,
             model: taskModel,

--- a/packages/project-aws/__tests__/isVpcEnabled.test.ts
+++ b/packages/project-aws/__tests__/isVpcEnabled.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
+import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { Vpc } from "~/pulumi/extensions/Vpc.js";
+import type { IProjectConfigModel } from "@webiny/project/abstractions/models/index.js";
+
+const PROD = true;
+const NOT_PROD = false;
+
+describe("isVpcEnabled", () => {
+    it("should use a VPC for production when no Infra.Vpc extension is registered", () => {
+        expect(isVpcEnabled(undefined, PROD)).toBe(true);
+    });
+
+    it("should not use a VPC outside production when no Infra.Vpc extension is registered", () => {
+        expect(isVpcEnabled(undefined, NOT_PROD)).toBe(false);
+    });
+
+    it("should honour an explicit enabled={false} even for production", () => {
+        // The regression this guards: production used to win over the explicit param, so
+        // `<Infra.Vpc enabled={false} />` silently did nothing on prod/production.
+        expect(isVpcEnabled(false, PROD)).toBe(false);
+        expect(isVpcEnabled(false, NOT_PROD)).toBe(false);
+    });
+
+    it("should honour an explicit enabled={true} outside production", () => {
+        expect(isVpcEnabled(true, NOT_PROD)).toBe(true);
+        expect(isVpcEnabled(true, PROD)).toBe(true);
+    });
+
+    it("should use a VPC whenever advanced params are given", () => {
+        expect(isVpcEnabled({ useVpcEndpoints: true }, NOT_PROD)).toBe(true);
+        expect(
+            isVpcEnabled(
+                {
+                    useExistingVpc: {
+                        lambdaFunctionsVpcConfig: {
+                            securityGroupIds: ["sg-1"],
+                            subnetIds: ["subnet-1"]
+                        }
+                    }
+                },
+                NOT_PROD
+            )
+        ).toBe(true);
+    });
+});
+
+/* Minimal project config exposing just the one method the getter calls. */
+const projectConfigWith = (params?: Record<string, unknown>): IProjectConfigModel =>
+    ({
+        extensionsByType: (type: unknown) =>
+            type === Vpc && params ? [{ params }] : ([] as unknown[])
+    }) as unknown as IProjectConfigModel;
+
+describe("getVpcConfigFromExtension", () => {
+    it("should return undefined when the extension is absent", () => {
+        expect(getVpcConfigFromExtension(projectConfigWith())).toBeUndefined();
+    });
+
+    it("should map enabled={false} to false", () => {
+        // isVpcEnabled relies on this exact value to distinguish "explicitly off" from "absent".
+        expect(getVpcConfigFromExtension(projectConfigWith({ enabled: false }))).toBe(false);
+    });
+
+    it("should map enabled={true} to true", () => {
+        expect(getVpcConfigFromExtension(projectConfigWith({ enabled: true }))).toBe(true);
+    });
+
+    it("should return the advanced params when any are given", () => {
+        expect(
+            getVpcConfigFromExtension(projectConfigWith({ enabled: true, useVpcEndpoints: true }))
+        ).toEqual({ useVpcEndpoints: true });
+    });
+
+    it("should prefer enabled={false} over advanced params", () => {
+        expect(
+            getVpcConfigFromExtension(projectConfigWith({ enabled: false, useVpcEndpoints: true }))
+        ).toBe(false);
+    });
+});

--- a/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
@@ -22,6 +22,7 @@ import type { WithServiceManifest } from "~/pulumi/utils/withServiceManifest.js"
 import { ApiScheduler } from "~/pulumi/apps/api/ApiScheduler.js";
 import { getProjectSdk } from "@webiny/project";
 import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
 import { getOsConfigFromExtension } from "~/pulumi/apps/extensions/getOsConfigFromExtension.js";
 import { handleGuardDutyEvents } from "./handleGuardDutyEvents.js";
 import { ApiPulumi, SetApiCustomDomains } from "~/abstractions/features/pulumi/index.js";
@@ -166,12 +167,9 @@ export const createApiPulumiApp = () => {
             const core = app.addModule(CoreOutput);
 
             // Register VPC config module to be available to other modules.
-            const vpcEnabled =
-                vpcExtensionsConfig === true ||
-                typeof vpcExtensionsConfig === "object" ||
-                isProduction;
-
-            app.addModule(VpcConfig, { enabled: vpcEnabled });
+            app.addModule(VpcConfig, {
+                enabled: isVpcEnabled(vpcExtensionsConfig, isProduction)
+            });
 
             const graphql = app.addModule(ApiGraphql, {
                 env: {

--- a/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
@@ -19,6 +19,7 @@ import { CorePulumi } from "~/abstractions/features/pulumi/index.js";
 import { corePulumi } from "~/pulumi/features/CorePulumi/index.js";
 import { getOsConfigFromExtension } from "~/pulumi/apps/extensions/getOsConfigFromExtension.js";
 import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
 import { applyAwsResourceTags, getAwsRegion } from "~/pulumi/apps/awsUtils.js";
 import { configureS3BucketMalwareProtection } from "./configureS3BucketMalwareProtection.js";
 import * as pulumi from "@pulumi/pulumi";
@@ -236,12 +237,9 @@ export function createCorePulumiApp() {
             const auditLogsDynamoDbTable = app.addModule(CoreAuditLogsDynamo, { protect });
 
             // Setup VPC
-            const vpcEnabled =
-                vpcExtensionsConfig === true ||
-                typeof vpcExtensionsConfig === "object" ||
-                isProduction;
-
-            const vpc = vpcEnabled ? app.addModule(CoreVpc) : null;
+            const vpc = isVpcEnabled(vpcExtensionsConfig, isProduction)
+                ? app.addModule(CoreVpc)
+                : null;
 
             // Setup Cognito
             const cognito = app.addModule(CoreCognito, {

--- a/packages/project-aws/src/pulumi/apps/extensions/isVpcEnabled.ts
+++ b/packages/project-aws/src/pulumi/apps/extensions/isVpcEnabled.ts
@@ -1,0 +1,29 @@
+import type { getVpcConfigFromExtension } from "./getVpcConfigFromExtension.js";
+
+export type VpcExtensionConfig = ReturnType<typeof getVpcConfigFromExtension>;
+
+/**
+ * Decides whether an app should use a VPC, from the `Infra.Vpc` extension config plus whether the
+ * target environment is a production one.
+ *
+ * Production environments get a VPC by default. An explicit `<Infra.Vpc enabled={false} />` beats
+ * that default: `enabled` is documented as a plain toggle, so ignoring it on production would
+ * silently do the opposite of what the project config asks for.
+ *
+ * Shared by the core and api apps so the two cannot disagree — a mismatch would leave the api app's
+ * Lambdas configured for subnets the core app never created.
+ */
+export function isVpcEnabled(config: VpcExtensionConfig, isProduction: boolean): boolean {
+    // Explicitly turned off via `<Infra.Vpc enabled={false} />`.
+    if (config === false) {
+        return false;
+    }
+
+    // Explicitly turned on, or given advanced params (useVpcEndpoints / useExistingVpc).
+    if (config === true || typeof config === "object") {
+        return true;
+    }
+
+    // No `Infra.Vpc` extension registered: a VPC is used for production environments only.
+    return isProduction;
+}

--- a/packages/website-builder-react/src/editorComponents/Grid.tsx
+++ b/packages/website-builder-react/src/editorComponents/Grid.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ComponentProps, ComponentPropsWithChildren } from "~/types.js";
+import { createGridClass, createGridStackingCss } from "./gridStyles.js";
 
 export const GridColumnComponent = ({
     inputs
@@ -23,7 +24,7 @@ type GridProps = ComponentProps<{
     reverseWhenStacked?: boolean;
 }>;
 
-export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
+export const GridComponent = ({ inputs, styles, element }: GridProps) => {
     const { gridLayout = "12", columns, columnGap, stackAtBreakpoint, reverseWhenStacked } = inputs;
     const rowConfig = gridLayout.split("-").map(size => parseInt(size));
     const rows: Column[][] = [];
@@ -36,22 +37,23 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
     // Number of pixels we need to subtract from each cell to ensure they fit in the grid with column gap
     const cellWidthReduction = columnGap ? columnGap - columnGap / rowConfig.length : 0;
 
-    const stackColumns = breakpoint === stackAtBreakpoint;
+    const gridClass = createGridClass(element.id);
 
-    if (stackColumns) {
-        styles.flexDirection = reverseWhenStacked ? "column-reverse" : "column";
-    }
+    // Columns stack via a CSS media query (see createGridStackingCss).
+    const stackCss = createGridStackingCss({ gridClass, stackAtBreakpoint, reverseWhenStacked });
 
     return (
-        <div style={styles}>
+        <div className={gridClass} style={styles}>
+            {/*
+                A media query can't be expressed in an inline `style` attribute (that only
+                holds declarations, not at-rules), so the stacking CSS is emitted as a
+                scoped <style> tag. A <style> is `display:none` and valid inside <body>,
+                so it doesn't affect the grid's flex layout.
+            */}
+            {stackCss ? <style dangerouslySetInnerHTML={{ __html: stackCss }} /> : null}
             {rows.map(columns => {
                 return columns.map((column, i) => (
-                    <Span
-                        key={i}
-                        stackColumns={stackColumns}
-                        size={rowConfig[i]}
-                        reductionInPx={cellWidthReduction}
-                    >
+                    <Span key={i} size={rowConfig[i]} reductionInPx={cellWidthReduction}>
                         <GridColumnComponent key={i} inputs={{ children: column.children }} />
                     </Span>
                 ));
@@ -63,15 +65,16 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
 interface SpanProps {
     size: number;
     reductionInPx: number;
-    stackColumns: boolean;
     children: React.ReactNode;
 }
 
-const Span = ({ size, children, reductionInPx, stackColumns }: SpanProps) => {
-    const width = stackColumns ? "100%" : `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
+const Span = ({ size, children, reductionInPx }: SpanProps) => {
+    // Base (row) width. The Grid's media query overrides this to 100% when stacked.
+    const width = `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
 
     return (
         <div
+            className="wb-grid-col"
             style={{
                 flex: `0 0 ${width}`,
                 maxWidth: width,

--- a/packages/website-builder-react/src/editorComponents/gridStyles.ts
+++ b/packages/website-builder-react/src/editorComponents/gridStyles.ts
@@ -1,0 +1,58 @@
+import { viewportManager } from "@webiny/website-builder-sdk";
+
+/**
+ * Builds a stable, SSR-consistent class scoped to a single grid instance
+ * (e.g. `wb-grid-<id>`), sanitized to a valid CSS class name.
+ */
+export const createGridClass = (elementId: string): string => {
+    return `wb-grid-${String(elementId).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+};
+
+interface CreateGridStackingCssParams {
+    /** Scoped class applied to the grid container (from `createGridClass`). */
+    gridClass: string;
+    /** Breakpoint name at (and below) which columns stack, e.g. "mobile". */
+    stackAtBreakpoint?: string;
+    /** Reverse the visual order of columns when stacked. */
+    reverseWhenStacked?: boolean;
+}
+
+/**
+ * Builds the media query that stacks a grid's columns at (and below) the given
+ * breakpoint's width.
+ *
+ * Stacking is expressed as CSS rather than JS so the layout is correct straight
+ * from the SSR HTML — no hydration, no viewport JS, no flash — the browser
+ * applies it by the real viewport width. The width comes from the theme's
+ * breakpoint definition (populated on both server and client via ContentSdk.init).
+ *
+ * Returns an empty string when no stacking breakpoint is configured (or the
+ * named breakpoint is unknown), in which case the grid never stacks.
+ */
+export const createGridStackingCss = ({
+    gridClass,
+    stackAtBreakpoint,
+    reverseWhenStacked
+}: CreateGridStackingCssParams): string => {
+    if (!stackAtBreakpoint) {
+        return "";
+    }
+
+    const breakpoint = viewportManager
+        .getViewport()
+        .breakpoints.find(bp => bp.name === stackAtBreakpoint);
+
+    if (!breakpoint) {
+        return "";
+    }
+
+    const direction = reverseWhenStacked ? "column-reverse" : "column";
+
+    // `!important` overrides the inline base (row) styles set on the elements.
+    return [
+        `@media (max-width: ${breakpoint.maxWidth}px) {`,
+        `  .${gridClass} { flex-direction: ${direction} !important; }`,
+        `  .${gridClass} > .wb-grid-col { flex: 0 0 100% !important; max-width: 100% !important; }`,
+        `}`
+    ].join("\n");
+};

--- a/packages/website-builder-sdk/src/ContentSdk.ts
+++ b/packages/website-builder-sdk/src/ContentSdk.ts
@@ -98,9 +98,11 @@ export class ContentSdk implements IContentSdk, IRedirects {
 
         const theme = Theme.from(config.theme ?? {});
 
-        if (environment.isClient()) {
-            viewportManager.setBreakpoints(theme.breakpoints);
-        }
+        // Populate breakpoints on the server too, so SSR can generate
+        // breakpoint-aware CSS (e.g. Grid stacking media queries) from the
+        // real theme widths. The resize listener stays client-only (it's
+        // guarded in the ViewportManager constructor).
+        viewportManager.setBreakpoints(theme.breakpoints);
 
         let editingSdk;
         if (environment.isEditing()) {


### PR DESCRIPTION
Forward-ports everything released in 6.4.10 onto `release/6.5.0`. Same pattern as #5615 (6.4.9) and #5392 (6.4.4): a branch cut from `release/6.5.0` with the fixes cherry-picked, not a `git merge`. A real merge of `v6.4.10` produces 172 conflicted files out of 237, because the earlier forward-ports were themselves cherry-picks and git has no record of them.

### What changed

Four of the five commits in `v6.4.9..v6.4.10` are here. The `chore: start release 6.4.10` version bump is excluded, and `c3824a6507` (guards in the FLP list decorators) was skipped because all four decorators on `release/6.5.0` already carry the identical guard.

| Cherry-picked | Outcome |
| --- | --- |
| `fix: unchecked result access (#5625)` | 10 conflicts, resolved by hand |
| `fix(api-headless-cms): handle unknown DZ templates gracefully in storage converter` | clean, byte-identical to the original |
| `fix: stack Grid columns via CSS media query (#5628)` | clean, byte-identical to the original |
| `fix(project-aws): let Infra.Vpc enabled={false} win over the production default (#5631)` | clean |

### Where to look

Commit by commit reads well here. `cdfa47cc96` is the only one with conflicts; the other three went in untouched.

**1. `api-aco/src/features/folder/EnsureFolderIsEmpty/EnsureFolderIsEmpty.ts`.** The one place the cherry-picked behavior was deliberately overridden. 6.5.0 already had a guard (`console.error`, `return true`) and git auto-merged the incoming one (`logger.error`, `return false`) directly above it, no conflict, first block wins. That flips a failed folder lookup from blocking a delete to allowing one. Collapsed to a single guard that logs through the injected `Logger` and keeps `return true`. Whether a lookup failure should block a delete is the judgment call worth a second opinion. Every other file in the cherry-pick was scanned for the same duplicate-guard pattern; this was the only instance.

**2. `api-file-manager/src/graphql/FmGraphQLSchema.ts` and `FmUploadGraphQLSchema.ts`.** Three guards written by hand rather than cherry-picked. The originals lived in `api-file-manager/src/graphql/{filesSchema,getFileByUrl,index}.ts` and `api-file-manager-s3/src/graphql/schema.ts`, none of which exist in 6.5.0. Those two files already guarded nearly every result; the three still missing were `loadModels()` and both `settingsResult.value` reads in the presigned-payload resolvers. `GetFileByUrlUseCase` already had its guard. Worth confirming these landed at the right call sites.

**3. `api-headless-cms-ddb-es/src/tasks/CreateElasticsearchIndexTask.ts`.** `createIndexTaskPlugin.ts` became this file on the DI pattern. Guard ported, `Logger` added to the constructor and the `dependencies` array. OpenSearch-only, so CI is the only signal on it.

**4. `api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts`.** #5625 calls `this.taskController.response.error(...)`, but 6.5.0 renamed that field to `controller`. Another silent auto-merge, caught only at build time. Fixed in its own commit.

The rest is mechanical. `createAcoContext.ts` and `api-file-manager/src/index.ts` only swap `context.container` / `context.security` for the destructured `container` / `security` that 6.5.0 uses. `api-scheduler/src/context.ts` split into an extension plugin and a context plugin in 6.5.0 and already has the guard, so that file is 6.5.0's version untouched.

To read just the hand-written parts:

```bash
git diff origin/release/6.5.0...merge/6.4.10-into-6.5.0 -- \
  packages/api-aco/src/features/folder/EnsureFolderIsEmpty \
  packages/api-file-manager/src/graphql \
  packages/api-headless-cms-ddb-es/src/tasks \
  packages/api-elasticsearch-tasks/src/tasks
```

### Testing

`yarn build`, `yarn adio`, `yarn lint`, `oxfmt` and `checkDistPaths` are green.

Local tests pass for the touched packages: `api-aco`, `api-core`, `api-file-manager`, `api-file-manager-aco`, `api-headless-cms` (938 tests), `api-headless-cms-bulk-actions`, `api-headless-cms-scheduler`, `api-headless-cms-tasks`, `api-headless-cms-workflows`, `api-mailer`, `api-website-builder`, `api-website-builder-scheduler`, `project-aws`.

Three caveats:

- `api-elasticsearch-tasks` and `api-headless-cms-ddb-es` are `ddb-os` only and cannot run without an OpenSearch cluster. Both carry hand-resolved changes, so their CI checks are the ones to watch.
- `api-workflows` has 4 failures in `WorkflowStateUseCases.test.ts` and `WorkflowUseCases.test.ts`, and `background-tasks` has 1 in `graphql/logs.test.ts` (`should list logs`). All five reproduce identically on untouched `release/6.5.0` source, so they predate this PR. They share a shape: `_id` present on one side of the comparison and absent on the other.
- `background-tasks` has a `__tests__` directory but no `vitest.config.ts`, so a package scan keyed on that file will skip it even though CI runs a job for it.

### Changelog

**Forward-port 6.4.10 fixes into 6.5.0**

The fixes shipped in 6.4.10 are now part of the 6.5.0 line, so upgrading from 6.4.10 will not lose them. This covers unhandled error cases across file manager, scheduler, workflows and content models, dynamic zone entries that reference a deleted template, grid columns not stacking on narrow screens, and VPC settings being ignored in production environments.

### Squash merge commit

```
fix: merge release/6.4.10 fixes into release/6.5.0 (#5669)
```
