### PR TITLE
chore(ci): run merged-branch cleanup by hand only

### DIFF
--- a/.github/workflows/deleteMergedBranches.yml
+++ b/.github/workflows/deleteMergedBranches.yml
@@ -4,8 +4,6 @@
 # For more information, run "github-actions-wac --help".
 name: Delete Merged Branches
 'on':
-  schedule:
-    - cron: 30 3 * * *
   workflow_dispatch:
     inputs:
       dryRun:

--- a/.github/workflows/wac/deleteMergedBranches.wac.ts
+++ b/.github/workflows/wac/deleteMergedBranches.wac.ts
@@ -1,10 +1,11 @@
 import { createWorkflow } from "github-actions-wac";
 import { createJob } from "./jobs/index.js";
 
-// Deletes branches whose pull request was merged more than a week ago, once a day.
+// Deletes branches whose pull request was merged more than a week ago.
 //
-// It can also be run by hand from the Actions tab, where `dryRun` lists what a run would delete
-// without deleting anything. The scheduled run passes no inputs, so it always deletes.
+// This runs by hand only, from the Actions tab: the daily schedule was removed so that nothing
+// deletes a branch without someone asking for it. `dryRun` lists what a run would delete without
+// deleting anything; leave it off to actually delete.
 //
 // GitHub's built-in "automatically delete head branches" setting deletes the branch the second the
 // PR merges, which is too soon: right after a merge is exactly when someone still wants to check
@@ -21,7 +22,6 @@ import { createJob } from "./jobs/index.js";
 export const deleteMergedBranches = createWorkflow({
     name: "Delete Merged Branches",
     on: {
-        schedule: [{ cron: "30 3 * * *" }],
         workflow_dispatch: {
             inputs: {
                 dryRun: {


### PR DESCRIPTION
### What changed

The Delete Merged Branches workflow no longer runs on a schedule. It used to fire every night at 03:30 UTC and delete any unprotected branch whose pull request was merged more than a week ago. Now it only runs when someone starts it from the Actions tab.

Nothing else about the workflow changed. Same keep list, same week of grace before a branch is eligible, same `dryRun` input for listing what a run would delete without deleting it.

`deleteReleaseBranch` is untouched, so release branches still get cleaned up when their pull request merges.

### Changelog

**Title line:** Merged branches are no longer deleted automatically

**Body:** Old branches were being cleaned up on a nightly timer. That timer is off, so branches now stick around until someone chooses to run the cleanup.

### Squash Merge Commit

```
chore(ci): run merged-branch cleanup by hand only (#5672)
chore(ci): drop the schedule from Delete Merged Branches (#5672)
```
