### PR TITLE
fix(website-builder-sdk): make breakpoint init callable from Server Components

### DIFF
--- a/packages/website-builder-react/src/editorComponents/gridStyles.test.ts
+++ b/packages/website-builder-react/src/editorComponents/gridStyles.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { breakpointsStore } from "@webiny/website-builder-sdk";
+import { createGridClass, createGridStackingCss } from "./gridStyles.js";
+
+const makeBreakpoint = (name: string, maxWidth: number) => ({
+    name,
+    title: "",
+    description: "",
+    icon: "",
+    minWidth: 0,
+    maxWidth
+});
+
+describe("createGridClass", () => {
+    it("scopes the class to the element id", () => {
+        expect(createGridClass("51ymnzews569243uf6wy1")).toBe("wb-grid-51ymnzews569243uf6wy1");
+    });
+
+    it("replaces characters that are not valid in a class name", () => {
+        expect(createGridClass("abc#0001.x")).toBe("wb-grid-abc-0001-x");
+    });
+});
+
+describe("createGridStackingCss", () => {
+    beforeEach(() => {
+        breakpointsStore.setBreakpoints([
+            makeBreakpoint("desktop", 4000),
+            makeBreakpoint("tablet", 991),
+            makeBreakpoint("mobile", 430)
+        ]);
+    });
+
+    it("returns nothing when no stacking breakpoint is configured", () => {
+        expect(createGridStackingCss({ gridClass: "wb-grid-a" })).toBe("");
+    });
+
+    it("returns nothing when the breakpoint is not part of the theme", () => {
+        expect(createGridStackingCss({ gridClass: "wb-grid-a", stackAtBreakpoint: "watch" })).toBe(
+            ""
+        );
+    });
+
+    it("stacks at the width the theme defines for that breakpoint", () => {
+        const css = createGridStackingCss({
+            gridClass: "wb-grid-a",
+            stackAtBreakpoint: "mobile"
+        });
+
+        expect(css).toContain("@media (max-width: 430px)");
+        expect(css).toContain(".wb-grid-a { flex-direction: column !important; }");
+        expect(css).toContain(".wb-grid-a > .wb-grid-col { flex: 0 0 100% !important;");
+    });
+
+    it("uses the tablet width when stacking at tablet", () => {
+        const css = createGridStackingCss({
+            gridClass: "wb-grid-a",
+            stackAtBreakpoint: "tablet"
+        });
+
+        expect(css).toContain("@media (max-width: 991px)");
+    });
+
+    it("reverses the column order when asked", () => {
+        const css = createGridStackingCss({
+            gridClass: "wb-grid-a",
+            stackAtBreakpoint: "mobile",
+            reverseWhenStacked: true
+        });
+
+        expect(css).toContain("flex-direction: column-reverse !important;");
+    });
+
+    it("scopes every rule to the given grid class", () => {
+        const css = createGridStackingCss({
+            gridClass: "wb-grid-b",
+            stackAtBreakpoint: "mobile"
+        });
+
+        expect(css).not.toContain("wb-grid-a");
+        expect(css.match(/\.wb-grid-b/g)).toHaveLength(2);
+    });
+});

--- a/packages/website-builder-react/src/editorComponents/gridStyles.ts
+++ b/packages/website-builder-react/src/editorComponents/gridStyles.ts
@@ -1,4 +1,4 @@
-import { viewportManager } from "@webiny/website-builder-sdk";
+import { breakpointsStore } from "@webiny/website-builder-sdk";
 
 /**
  * Builds a stable, SSR-consistent class scoped to a single grid instance
@@ -38,9 +38,7 @@ export const createGridStackingCss = ({
         return "";
     }
 
-    const breakpoint = viewportManager
-        .getViewport()
-        .breakpoints.find(bp => bp.name === stackAtBreakpoint);
+    const breakpoint = breakpointsStore.getBreakpoint(stackAtBreakpoint);
 
     if (!breakpoint) {
         return "";

--- a/packages/website-builder-sdk/src/BreakpointsStore.test.ts
+++ b/packages/website-builder-sdk/src/BreakpointsStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { breakpointsStore } from "./BreakpointsStore.js";
+import { viewportManager } from "./ViewportManager.js";
+import type { Breakpoint } from "~/types.js";
+
+const makeBreakpoint = (name: string, maxWidth: number): Breakpoint => ({
+    name,
+    title: "",
+    description: "",
+    icon: "",
+    minWidth: 0,
+    maxWidth
+});
+
+const themeBreakpoints = [
+    makeBreakpoint("desktop", 4000),
+    makeBreakpoint("tablet", 991),
+    makeBreakpoint("mobile", 430)
+];
+
+describe("breakpointsStore", () => {
+    // Runs first on purpose: the store is a module singleton, so the fallback is
+    // only observable before a theme is applied.
+    it("falls back to a full-width desktop breakpoint before a theme is applied", () => {
+        expect(breakpointsStore.getBreakpoints()).toEqual([
+            expect.objectContaining({ name: "desktop", maxWidth: 4000 })
+        ]);
+    });
+
+    it("returns the breakpoints it was given", () => {
+        breakpointsStore.setBreakpoints(themeBreakpoints);
+
+        expect(breakpointsStore.getBreakpoints()).toEqual(themeBreakpoints);
+    });
+
+    it("looks a breakpoint up by name", () => {
+        breakpointsStore.setBreakpoints(themeBreakpoints);
+
+        expect(breakpointsStore.getBreakpoint("mobile")?.maxWidth).toBe(430);
+        expect(breakpointsStore.getBreakpoint("tablet")?.maxWidth).toBe(991);
+    });
+
+    it("returns undefined for a name the theme does not define", () => {
+        breakpointsStore.setBreakpoints(themeBreakpoints);
+
+        expect(breakpointsStore.getBreakpoint("watch")).toBeUndefined();
+    });
+
+    it("is what ViewportManager reports, so both sides agree", () => {
+        breakpointsStore.setBreakpoints(themeBreakpoints);
+
+        expect(viewportManager.getViewport().breakpoints).toEqual(themeBreakpoints);
+    });
+
+    it("still accepts writes through the deprecated ViewportManager method", () => {
+        const single = [makeBreakpoint("desktop", 4000)];
+        viewportManager.setBreakpoints(single);
+
+        expect(breakpointsStore.getBreakpoints()).toEqual(single);
+
+        breakpointsStore.setBreakpoints(themeBreakpoints);
+    });
+});

--- a/packages/website-builder-sdk/src/BreakpointsStore.ts
+++ b/packages/website-builder-sdk/src/BreakpointsStore.ts
@@ -1,0 +1,46 @@
+import type { Breakpoint } from "~/types.js";
+
+/**
+ * Used until a theme is applied. Server rendering and Next.js builds rely on it,
+ * so it has to cover the full width range.
+ */
+const fallbackBreakpoint: Breakpoint = {
+    name: "desktop",
+    title: "",
+    description: "",
+    icon: "",
+    minWidth: 0,
+    maxWidth: 4000
+};
+
+/**
+ * Holds the active theme's breakpoints.
+ *
+ * This is deliberately kept out of `ViewportManager`. `ViewportManager` observes
+ * the browser viewport, so it is a client module (`"use client"`), and a Server
+ * Component that imports it receives a client reference rather than the real
+ * object. Breakpoints are plain configuration that the server needs too, for
+ * example to generate breakpoint-aware CSS while rendering, so they live here in
+ * a module both sides can read and write.
+ */
+class BreakpointsStore {
+    private breakpoints: Breakpoint[] = [fallbackBreakpoint];
+
+    public setBreakpoints(breakpoints: Breakpoint[]): void {
+        this.breakpoints = breakpoints;
+    }
+
+    public getBreakpoints(): Breakpoint[] {
+        return this.breakpoints;
+    }
+
+    /**
+     * Look up a single breakpoint by name. Returns `undefined` when the name is
+     * not part of the active theme.
+     */
+    public getBreakpoint(name: string): Breakpoint | undefined {
+        return this.breakpoints.find(breakpoint => breakpoint.name === name);
+    }
+}
+
+export const breakpointsStore = new BreakpointsStore();

--- a/packages/website-builder-sdk/src/ContentSdk.ts
+++ b/packages/website-builder-sdk/src/ContentSdk.ts
@@ -17,7 +17,7 @@ import { ApiClient } from "~/dataProviders/ApiClient.js";
 import { DefaultDataProvider } from "~/dataProviders/DefaultDataProvider.js";
 import type { WebsiteBuilderThemeInput } from "./types/WebsiteBuilderTheme.js";
 import { Theme } from "./Theme.js";
-import { viewportManager } from "./ViewportManager.js";
+import { breakpointsStore } from "./BreakpointsStore.js";
 import type { IRedirects } from "~/IRedirects.js";
 import { RedirectsProvider } from "~/dataProviders/RedirectsProvider.js";
 
@@ -95,11 +95,13 @@ export class ContentSdk implements IContentSdk, IRedirects {
 
         const theme = Theme.from(config.theme ?? {});
 
-        // Populate breakpoints on the server too, so SSR can generate
-        // breakpoint-aware CSS (e.g. Grid stacking media queries) from the
-        // real theme widths. The resize listener stays client-only (it's
-        // guarded in the ViewportManager constructor).
-        viewportManager.setBreakpoints(theme.breakpoints);
+        // Breakpoints are populated on the server too, so that SSR can generate
+        // breakpoint-aware CSS (Grid stacking media queries, for example) from
+        // the real theme widths. They are stored outside ViewportManager, which
+        // is a client module: importing it from a Server Component yields a
+        // client reference whose methods cannot be called. Keeping this in
+        // `breakpointsStore` lets `init()` run in any environment.
+        breakpointsStore.setBreakpoints(theme.breakpoints);
 
         let editingSdk;
         if (environment.isEditing()) {

--- a/packages/website-builder-sdk/src/ViewportManager.ts
+++ b/packages/website-builder-sdk/src/ViewportManager.ts
@@ -1,6 +1,7 @@
 "use client";
 import type { Breakpoint } from "~/types.js";
 import { environment } from "~/Environment.js";
+import { breakpointsStore } from "~/BreakpointsStore.js";
 
 export interface ViewportInfo {
     width: number;
@@ -20,20 +21,6 @@ export class ViewportManager {
     private isChanging: boolean;
     private changeTimer: number | null;
 
-    /**
-     * We need this fallback breakpoint for server environments.
-     */
-    private breakpoints: Breakpoint[] = [
-        {
-            name: "desktop",
-            title: "",
-            description: "",
-            icon: "",
-            minWidth: 0,
-            maxWidth: 4000
-        }
-    ];
-
     constructor(timeout: number = 150) {
         this.changeTimeout = timeout;
         this.changeStartSubscribers = new Set();
@@ -49,8 +36,13 @@ export class ViewportManager {
         }
     }
 
+    /**
+     * @deprecated Breakpoints live in `breakpointsStore`, which the server can
+     * write to as well. Call `breakpointsStore.setBreakpoints` instead. Kept as
+     * a delegate so existing callers keep working.
+     */
     public setBreakpoints(breakpoints: Breakpoint[]) {
-        this.breakpoints = breakpoints;
+        breakpointsStore.setBreakpoints(breakpoints);
     }
 
     public onViewportChangeStart(callback: (info: ViewportInfo) => void): () => void {
@@ -104,7 +96,8 @@ export class ViewportManager {
     }
 
     private getViewportInfo(): ViewportInfo {
-        const modes = [...this.breakpoints].reverse();
+        const breakpoints = breakpointsStore.getBreakpoints();
+        const modes = [...breakpoints].reverse();
         const viewport = environment.isClient()
             ? {
                   width: window.innerWidth,
@@ -126,7 +119,7 @@ export class ViewportManager {
 
         const [breakpoint] = modes.filter(mode => mode.maxWidth >= viewport.width);
 
-        return { ...viewport, breakpoint: breakpoint.name, breakpoints: this.breakpoints };
+        return { ...viewport, breakpoint: breakpoint.name, breakpoints };
     }
 
     private notifySubscribers(

--- a/packages/website-builder-sdk/src/index.ts
+++ b/packages/website-builder-sdk/src/index.ts
@@ -9,6 +9,7 @@ export * from "./Logger.js";
 export * from "./FunctionConverter.js";
 export * from "./createInput.js";
 export * from "./MouseTracker.js";
+export * from "./BreakpointsStore.js";
 export * from "./ViewportManager.js";
 export * from "./messenger/Messenger.js";
 export * from "./messenger/MessageOrigin.js";


### PR DESCRIPTION
Fixes the RSC initialization failure reported against 6.4.10.

## Problem

`ContentSdk.ts` imports the viewport singleton directly:

```ts
import { viewportManager } from "./ViewportManager.js";
```

`ViewportManager.ts` is marked `"use client"`. That directive is a module boundary, so in the server graph the bundler replaces the module's exports with client references. When the SDK is initialized inside an App Router Server Component, `viewportManager` is therefore a reference placeholder rather than the singleton, and calling a method on it throws:

```
TypeError: viewportManager.setBreakpoints is not a function
```

It throws during `init()`, before any API request, so page loading and redirect resolution both fail from RSC.

Minimal trigger:

```tsx
import { ContentSdk } from "@webiny/website-builder-sdk";

export const dynamic = "force-dynamic";

export default function Page() {
  const sdk = new ContentSdk();
  sdk.init({ apiHost: "https://api.example.com", apiKey: "test-key", apiTenant: "root" });
  return <div>SDK initialized</div>;
}
```

This is a regression from #5628, which removed the `environment.isClient()` guard so that Grid could emit responsive CSS during SSR. The import itself predates that PR and was harmless, because importing a client reference only fails when you call a method on it, and the guard meant nothing ever did on the server. Removing the guard started calling it. Restoring the guard would fix the crash but lose the SSR CSS, so it is not the fix here.

Why it was missed: the change was never run through a production build of a starter app against the actually built packages. Verification went through hand-patched `node_modules`, which is where a build-time module-boundary error like this hides. One `next build` surfaces it immediately, as the check below shows.

## Fix

Breakpoints are plain configuration that the server needs too, so they move out of the client-only `ViewportManager` into a server-safe store. This follows the separation suggested in the report.

- New `BreakpointsStore` owns the breakpoint list and the desktop fallback, with no `"use client"` directive, so it is a shared module usable from either graph.
- `ViewportManager` keeps browser viewport observation and reads breakpoints from the store. `setBreakpoints` remains as a deprecated delegate so existing callers, including the reporter's compatibility guard, keep working.
- `ContentSdk` no longer imports `ViewportManager` at all, so `init()` runs in any environment.
- `createGridStackingCss` reads widths from the store, removing the client-only dependency from the SSR CSS path.

Note that the store is a module usable on both sides, not state shared across the boundary. Each graph gets its own instance, populated by its own `init()` call, and nothing is serialized between them.

This addresses all three requirements from the report: content and redirect loading work from RSC without touching client-only exports, breakpoint initialization still happens during client-component SSR, and browser and editor behavior are unchanged. The compatibility guard can be removed.

## Verification

Reproduced and confirmed against the reporter's scenario in a real Next.js app, using the built packages:

- Before: `next build` fails with `TypeError: dE.viewportManager.setBreakpoints is not a function`.
- After: build succeeds, the Server Component route renders, and `/grid-page` still emits `@media (max-width: ...)` in the raw HTTP response, so Grid stacking is intact.

Also added the unit tests that were missing on #5628:

- `BreakpointsStore.test.ts` covers the fallback, lookup by name, and that `ViewportManager` reports what the store holds, including through the deprecated setter.
- `gridStyles.test.ts` covers class scoping and the generated media query, including per-breakpoint widths and the reverse case.

## Follow-up, not in this PR

`next` has neither #5628 nor this fix, so the Grid CSS work and this repair both still need forward-porting or 6.5 loses them.