### PR TITLE
feat(project-aws): expose CloudFront minimumProtocolVersion for custom domains

### DIFF
--- a/packages/project-aws/src/pulumi/apps/admin/createAdminPulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/admin/createAdminPulumiApp.ts
@@ -18,11 +18,13 @@ export const createAdminPulumiApp = async () => {
             const [adminDomains] = projectConfig.extensionsByType(adminCustomDomainsExt);
 
             if (adminDomains) {
-                const { domains, sslMethod, certificateArn } = adminDomains.params;
+                const { domains, sslMethod, certificateArn, minimumProtocolVersion } =
+                    adminDomains.params;
                 return {
                     domains,
                     sslSupportMethod: sslMethod,
-                    acmCertificateArn: certificateArn
+                    acmCertificateArn: certificateArn,
+                    minimumProtocolVersion
                 };
             }
 

--- a/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
@@ -257,11 +257,13 @@ export const createApiPulumiApp = () => {
 
             const [apiCustomDomains] = projectConfig.extensionsByType(apiCustomDomainsExt);
             if (apiCustomDomains) {
-                const { domains, sslMethod, certificateArn } = apiCustomDomains.params;
+                const { domains, sslMethod, certificateArn, minimumProtocolVersion } =
+                    apiCustomDomains.params;
                 applyCustomDomain(cloudfront, {
                     domains,
                     sslSupportMethod: sslMethod,
-                    acmCertificateArn: certificateArn
+                    acmCertificateArn: certificateArn,
+                    minimumProtocolVersion
                 });
             }
 

--- a/packages/project-aws/src/pulumi/apps/customDomain.ts
+++ b/packages/project-aws/src/pulumi/apps/customDomain.ts
@@ -2,10 +2,35 @@ import { type Input } from "@pulumi/pulumi";
 import type * as aws from "@pulumi/aws";
 import { type PulumiAppResource } from "@webiny/pulumi";
 
+/**
+ * TLS security policies CloudFront accepts for `minimumProtocolVersion`.
+ * Pulumi types the property as a plain string, so the accepted values are
+ * listed here to keep the public configuration typed.
+ */
+export const minimumProtocolVersions = [
+    "SSLv3",
+    "TLSv1",
+    "TLSv1_2016",
+    "TLSv1.1_2016",
+    "TLSv1.2_2018",
+    "TLSv1.2_2019",
+    "TLSv1.2_2021"
+] as const;
+
+export type MinimumProtocolVersion = (typeof minimumProtocolVersions)[number];
+
 export interface CustomDomainParams {
     domains: Input<string[]>;
     acmCertificateArn: Input<string>;
     sslSupportMethod?: Input<string>;
+    /**
+     * Minimum TLS version viewers must support in order to connect.
+     *
+     * Left unset by default, which keeps whatever CloudFront applies on its
+     * own. Setting it on an existing project updates the distribution, and
+     * raising it can lock out clients that only speak older TLS versions.
+     */
+    minimumProtocolVersion?: Input<MinimumProtocolVersion>;
 }
 
 export function applyCustomDomain(
@@ -16,6 +41,11 @@ export function applyCustomDomain(
 
     cloudfront.config.viewerCertificate({
         acmCertificateArn: params.acmCertificateArn,
-        sslSupportMethod: params.sslSupportMethod ?? "sni-only"
+        sslSupportMethod: params.sslSupportMethod ?? "sni-only",
+        // Only sent when configured, so distributions that do not set it are
+        // left exactly as they were.
+        ...(params.minimumProtocolVersion
+            ? { minimumProtocolVersion: params.minimumProtocolVersion }
+            : {})
     });
 }

--- a/packages/project-aws/src/pulumi/extensions/AdminCustomDomains.ts
+++ b/packages/project-aws/src/pulumi/extensions/AdminCustomDomains.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { defineExtension } from "@webiny/project/defineExtension/index.js";
+import { minimumProtocolVersions } from "~/pulumi/apps/customDomain.js";
 
 export const AdminCustomDomains = defineExtension({
     type: "Infra/Admin/CustomDomains",
@@ -13,6 +14,12 @@ export const AdminCustomDomains = defineExtension({
             .default("sni-only"),
         certificateArn: z
             .string()
-            .describe("The ARN of the SSL/TLS certificate to use for the custom domains.")
+            .describe("The ARN of the SSL/TLS certificate to use for the custom domains."),
+        minimumProtocolVersion: z
+            .enum(minimumProtocolVersions)
+            .describe(
+                "The minimum TLS version viewers must support. Left to CloudFront's own default when omitted."
+            )
+            .optional()
     })
 });

--- a/packages/project-aws/src/pulumi/extensions/ApiCustomDomains.ts
+++ b/packages/project-aws/src/pulumi/extensions/ApiCustomDomains.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { defineExtension } from "@webiny/project/defineExtension/index.js";
+import { minimumProtocolVersions } from "~/pulumi/apps/customDomain.js";
 
 export const ApiCustomDomains = defineExtension({
     type: "Infra/Api/CustomDomains",
@@ -13,6 +14,12 @@ export const ApiCustomDomains = defineExtension({
             .default("sni-only"),
         certificateArn: z
             .string()
-            .describe("The ARN of the SSL/TLS certificate to use for the custom domains.")
+            .describe("The ARN of the SSL/TLS certificate to use for the custom domains."),
+        minimumProtocolVersion: z
+            .enum(minimumProtocolVersions)
+            .describe(
+                "The minimum TLS version viewers must support. Left to CloudFront's own default when omitted."
+            )
+            .optional()
     })
 });


### PR DESCRIPTION
Adds a supported way to set the CloudFront TLS security policy on custom domains, so projects no longer have to patch `@webiny/project-aws`.

## Problem

`applyCustomDomain()` built the `viewerCertificate` from the certificate ARN and SSL support method only:

```ts
cloudfront.config.viewerCertificate({
    acmCertificateArn: params.acmCertificateArn,
    sslSupportMethod: params.sslSupportMethod ?? "sni-only"
});
```

`minimumProtocolVersion` was never sent, so CloudFront applied its own default and there was no supported way to change it. Patching `pulumi/apps/customDomain.js` was the only option.

## Change

`CustomDomainParams` takes an optional `minimumProtocolVersion`, and the property is added to `viewerCertificate` **only when set**:

```ts
...(params.minimumProtocolVersion
    ? { minimumProtocolVersion: params.minimumProtocolVersion }
    : {})
```

It is exposed on both public custom-domain extensions:

```ts
{
  type: "Infra/Admin/CustomDomains",
  params: {
    domains: ["admin.example.com"],
    certificateArn: "arn:aws:acm:...",
    minimumProtocolVersion: "TLSv1.2_2021"
  }
}
```

Against the four requirements from the request:

- **All CloudFront-compatible TLS policies.** Typed as `SSLv3`, `TLSv1`, `TLSv1_2016`, `TLSv1.1_2016`, `TLSv1.2_2018`, `TLSv1.2_2019`, `TLSv1.2_2021`, AWS's full documented set. Pulumi types the field as a bare `string`, so the union is maintained in `customDomain.ts` and shared by both extension schemas.
- **Available through the public API.** On `Infra/Admin/CustomDomains` and `Infra/Api/CustomDomains`, and on the `SetAdminCustomDomains` / `SetApiCustomDomains` abstractions for free, since those already take `CustomDomainParams`. Those are re-exported from `webiny/infra`.
- **Backward compatible when omitted.** The key is not emitted at all, so existing distributions produce no diff.
- **Works for Admin and other custom-domain distributions.** Every custom-domain CloudFront distribution goes through `applyCustomDomain()`, so Admin, API and the blue/green router all pick it up. Only Admin and API have a public extension to configure it, which matches where custom domains are actually configurable today.

## On defaults

Deliberately no default. Raising the minimum TLS version rewrites the distribution and can lock out clients on older TLS, so it stays opt-in. Moving the default to something modern is worth doing, but it belongs in a major rather than a patch.

## Files

- `pulumi/apps/customDomain.ts` — optional param, typed policy list, conditional passthrough.
- `pulumi/extensions/AdminCustomDomains.ts`, `pulumi/extensions/ApiCustomDomains.ts` — optional enum on the schemas.
- `pulumi/apps/admin/createAdminPulumiApp.ts`, `pulumi/apps/api/createApiPulumiApp.ts` — pass the value through.

## Verification

- `yarn build -p @webiny/project-aws` clean, and the emitted `customDomain.js` shows the property omitted unless set.
- The shared policy list is a plain const, and `customDomain.js` compiles to zero runtime imports (the Pulumi imports are type-only), so importing it from the extension modules adds no runtime dependency.
- `yarn test packages/project-aws` passes (25). `lint` and `adio` clean.

This should let the reporter drop their `@webiny/project-aws` patch.