### PR TITLE
fix(api-headless-cms-ddb-es): searchable json full text search

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
@@ -85,7 +85,15 @@ export const applyFullTextSearch = (params: Params): void => {
             } else if (field.systemField) {
                 return field.path || field.field.storageId;
             }
-            return `values.${field.path || field.field.storageId}`;
+            const path = `values.${field.path || field.field.storageId}`;
+            /**
+             * Searchable JSON fields are indexed as objects, so the actual searchable values
+             * live on the nested keys. Target them all via a wildcard.
+             */
+            if (field.type === "searchable-json") {
+                return `${path}.*`;
+            }
+            return path;
         },
         fields,
         query,

--- a/packages/api-website-builder/__tests__/graphql/pages.gql.ts
+++ b/packages/api-website-builder/__tests__/graphql/pages.gql.ts
@@ -198,9 +198,15 @@ export const GET_PAGE_REVISIONS = /* GraphQL */ `
 `;
 
 export const LIST_PAGES = /* GraphQL */ `
-    query ListPages($limit: Int, $after: String, $where: WbPagesListWhereInput) {
+    query ListPages(
+        $limit: Int
+        $after: String
+        $where: WbPagesListWhereInput
+        $sort: [WbPageListSorter]
+        $search: String
+    ) {
         websiteBuilder {
-            listPages(limit: $limit, after: $after, where: $where) {
+            listPages(limit: $limit, after: $after, where: $where, sort: $sort, search: $search) {
                 data ${PAGE_DATA_FIELD}
                 error ${ERROR_FIELD}
                 meta {

--- a/packages/api-website-builder/__tests__/pages.search.test.ts
+++ b/packages/api-website-builder/__tests__/pages.search.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useGraphQlHandler } from "./utils/useGraphQlHandler.js";
+
+/**
+ * The `properties` field of the page model is a `searchableJson` field, which means the values
+ * stored within it (`title`, `path`, ...) must be usable via the full-text search (`search` arg).
+ */
+const searchPageMocks = {
+    alpha: {
+        properties: {
+            title: "Alpha Landing Page",
+            path: "/alpha-landing"
+        },
+        metadata: {},
+        bindings: {},
+        elements: [],
+        location: {
+            folderId: "root"
+        }
+    },
+    beta: {
+        properties: {
+            title: "Beta Pricing Page",
+            path: "/beta-pricing"
+        },
+        metadata: {},
+        bindings: {},
+        elements: [],
+        location: {
+            folderId: "root"
+        }
+    },
+    gamma: {
+        properties: {
+            title: "Gamma Contact Page",
+            path: "/gamma-contact"
+        },
+        metadata: {},
+        bindings: {},
+        elements: [],
+        location: {
+            folderId: "root"
+        }
+    }
+};
+
+describe("Pages Search", () => {
+    let handler: ReturnType<typeof useGraphQlHandler>;
+
+    const listPages = async (variables: Record<string, any>) => {
+        const [response] = await handler.wb.listPages(variables);
+        const { data, error, meta } = response.data.websiteBuilder.listPages;
+
+        if (error) {
+            throw new Error(`${error.code}: ${error.message}`);
+        }
+
+        return { titles: data.map((page: any) => page.properties.title).sort(), meta };
+    };
+
+    beforeEach(async () => {
+        handler = useGraphQlHandler({});
+
+        for (const data of Object.values(searchPageMocks)) {
+            const [response] = await handler.wb.createPage({ data });
+            expect(response.data.websiteBuilder.createPage.error).toBeNull();
+        }
+
+        // Storage is eventually consistent, so wait until all the pages become listable.
+        await handler.until(
+            () => handler.wb.listPages({ where: {} }),
+            ([response]: [any]) => response.data.websiteBuilder.listPages.data.length === 3
+        );
+    });
+
+    it("should list all pages when no search term is given", async () => {
+        const { titles, meta } = await listPages({ where: {} });
+
+        expect(titles).toEqual(["Alpha Landing Page", "Beta Pricing Page", "Gamma Contact Page"]);
+        expect(meta.totalCount).toBe(3);
+    });
+
+    it("should find a page by a word contained in the page title", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "Pricing" });
+
+        expect(titles).toEqual(["Beta Pricing Page"]);
+        expect(meta.totalCount).toBe(1);
+    });
+
+    it("should find a page by a partial word contained in the page title", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "Land" });
+
+        expect(titles).toEqual(["Alpha Landing Page"]);
+        expect(meta.totalCount).toBe(1);
+    });
+
+    it("should find a page by multiple words contained in the page title", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "Gamma Contact" });
+
+        expect(titles).toEqual(["Gamma Contact Page"]);
+        expect(meta.totalCount).toBe(1);
+    });
+
+    it("should find a page by a term contained in the page path", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "beta-pricing" });
+
+        expect(titles).toEqual(["Beta Pricing Page"]);
+        expect(meta.totalCount).toBe(1);
+    });
+
+    it("should find all pages by a term shared by all of them", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "Page" });
+
+        expect(titles).toEqual(["Alpha Landing Page", "Beta Pricing Page", "Gamma Contact Page"]);
+        expect(meta.totalCount).toBe(3);
+    });
+
+    it("should not find any page when the term matches nothing", async () => {
+        const { titles, meta } = await listPages({ where: {}, search: "zzz-no-such-page" });
+
+        expect(titles).toEqual([]);
+        expect(meta.totalCount).toBe(0);
+    });
+});

--- a/packages/api-website-builder/ci.config.json
+++ b/packages/api-website-builder/ci.config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../.github/workflows/ci.config.schema.json",
+  "vitest": {
+    "storageOps": ["ddb", "ddb-os,ddb"]
+  }
+}


### PR DESCRIPTION
## Changes

Searching for pages in the Website Builder returned an empty result set on `ddb+opensearch` deployments, no matter the search term.

The page model stores `properties` as a `searchableJson` field, which lands in the index as an **object**:

```json
"values": {
  "searchable-json@properties": { "title": "Beta Pricing Page", "path": "/beta-pricing" }
}
```

`applyFullTextSearch` built the field path as the object itself, so the emitted query targeted a field that holds no text:

```json
"query_string": {
  "fields": ["id", "entryId", "values.searchable-json@properties", "..."],
  "query": "*beta pricing*",
  "default_operator": "and"
}
```

A `query_string` against an object field name matches nothing, and since the clause sits in `must`, **every** search returned zero hits. DynamoDB-only deployments were unaffected, because their filter flattens the object's leaf values in memory — which is why this never surfaced locally or in CI.

### Fix

`searchable-json` fields now resolve to `values.<storageId>.*`, so the query targets the nested leaf values instead of the object.

### Also in this PR

- **New test suite** — `packages/api-website-builder/__tests__/pages.search.test.ts`, covering search by whole word, partial word, multiple words, path fragment, a term shared by all pages, and a non-matching term. `$sort` / `$search` were added to the test-side `LIST_PAGES` query; the schema already accepted both, the test GraphQL document just never passed them.
- **`packages/api-website-builder/ci.config.json`** — `storageOps: ["ddb", "ddb-os,ddb"]`, matching `api-headless-cms`. Without it, CI only ever ran this package against `ddb`, which is the reason this class of bug was invisible.

## How Has This Been Tested?

The new suite fails 5/7 against OpenSearch before the fix and passes fully after it.

| Suite | Result |
| --- | --- |
| `yarn test:os packages/api-headless-cms` | 878 passed, 16 skipped (291 files) |
| `yarn test:os packages/api-headless-cms-ddb-es` | 112 passed (31 files) |
| `yarn test:os packages/api-website-builder` | 202 passed, 5 skipped |
| `yarn test packages/api-website-builder` | 202 passed, 5 skipped |

One note: an early full-suite run of `api-headless-cms-ddb-es` hit a single failure in `__tests__/tasks/createIndexTask.test.ts`, which asserts `toEqual` on an array of tenant index names whose order isn't deterministic. It passes in isolation both with and without this change, and the full suite passed clean on re-run — a pre-existing order-dependent flake, not fallout from this PR. Worth sorting before comparing in a separate change.

## Documentation

No documentation changes needed — this restores the documented behaviour of the `search` argument on `listPages`.
