### PR TITLE
refactor(background-tasks): split task definitions into metadata and handler

### DIFF
--- a/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
+++ b/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
@@ -1,4 +1,5 @@
 import zod from "zod";
+import type { Constructor } from "@webiny/di";
 import { createAbstraction } from "@webiny/feature/api";
 import type { GenericRecord } from "@webiny/api/types";
 import type { ITask } from "~/features/task/TaskService/index.js";
@@ -99,12 +100,13 @@ export type ITaskLifecycleHook<
 };
 
 /**
- * Core TaskDefinition - minimal interface
+ * What a task IS: identity and runtime policy, with no behaviour and no dependencies.
+ *
+ * Listing tasks, resolving one by id, and applying defaults all need only this. Keeping it free of
+ * dependencies is the whole point — `GetTaskDefinitionUseCase` builds every registered definition
+ * to find one by id, so anything expensive here is paid 29 times per lookup.
  */
-export interface ITaskDefinition<
-    I extends ITaskInput = ITaskInput,
-    O extends ITaskOutput = ITaskOutput
-> {
+export interface ITaskMetadata {
     id: string;
     title: string;
     description?: string;
@@ -112,7 +114,20 @@ export interface ITaskDefinition<
     databaseLogs?: boolean;
     isPrivate?: boolean;
     selfCleanup?: ISelfCleanup;
+}
 
+/**
+ * What a task DOES. This is the half that carries dependencies (a CMS context, an OpenSearch
+ * client), so it is built only for the task actually being run.
+ *
+ * The lifecycle hooks live here rather than on {@link ITaskMetadata} because they need the same
+ * dependencies `run()` does — see `MockDataManagerTask`, whose `onError` and `onAbort` both use the
+ * OpenSearch client injected for `run()`.
+ */
+export interface ITaskHandler<
+    I extends ITaskInput = ITaskInput,
+    O extends ITaskOutput = ITaskOutput
+> {
     /**
      * Core run method - receives ONLY input params
      * All runtime dependencies (logging, state management, etc.) come from TaskController
@@ -136,12 +151,43 @@ export interface ITaskDefinition<
     ): GenericRecord<keyof I, zod.Schema> | zod.Schema;
 }
 
+/**
+ * Core TaskDefinition - minimal interface
+ *
+ * TRANSITIONAL SHAPE. A definition supplies its behaviour in one of two ways:
+ *
+ *  - the new way: `handler` names a {@link ITaskHandler} class, which the runner builds only for the
+ *    task it is about to run;
+ *  - the old way: the definition implements `run()` and the hooks itself, which forces every
+ *    definition (and every dependency it injects) to be built just to look one up by id.
+ *
+ * `run` is optional ONLY to let both shapes coexist while packages migrate. Once every definition
+ * carries a `handler`, this interface becomes `ITaskMetadata & { handler }` and the optionality
+ * goes away. Exactly one of `run` or `handler` must be present; `GetTaskDefinitionUseCase` fails
+ * with {@link TaskDefinitionNotRunnableError} if neither is.
+ */
+export interface ITaskDefinition<
+    I extends ITaskInput = ITaskInput,
+    O extends ITaskOutput = ITaskOutput
+>
+    extends ITaskMetadata, Partial<ITaskHandler<I, O>> {
+    handler?: Constructor<ITaskHandler<I, O>>;
+}
+
 export interface ITaskCreateInputValidationParams {
     validator: typeof zod;
 }
 
 /** Define a long-running background task with lifecycle hooks. */
 export const TaskDefinition = createAbstraction<ITaskDefinition>("TaskDefinition");
+
+/**
+ * The behaviour half of a task, resolved on demand by the runner via
+ * `container.resolveImplementation(definition.handler)`. Registered implementations are NOT
+ * registered against this abstraction — the definition points at the class directly, exactly as
+ * `HttpRouteDefinition` points at its `HttpRouteHandler`.
+ */
+export const TaskHandler = createAbstraction<ITaskHandler>("TaskHandler");
 
 /**
  * IRunnableTaskDefinition represents a TaskDefinition after decoration/processing.
@@ -151,11 +197,34 @@ export const TaskDefinition = createAbstraction<ITaskDefinition>("TaskDefinition
 export interface IRunnableTaskDefinition<
     I extends ITaskInput = ITaskInput,
     O extends ITaskOutput = ITaskOutput
-> extends ITaskDefinition<I, O> {
+>
+    extends ITaskMetadata, ITaskHandler<I, O> {
     // Override optional properties to be required with guaranteed values
     isPrivate: boolean;
     databaseLogs: boolean;
     maxIterations: number;
+}
+
+export namespace TaskHandler {
+    export type Interface<
+        I extends ITaskInput = ITaskInput,
+        O extends ITaskOutput = ITaskOutput
+    > = ITaskHandler<I, O>;
+
+    export type RunParams<
+        I extends ITaskInput = ITaskInput,
+        O extends ITaskOutput = ITaskOutput
+    > = ITaskRunParams<I, O>;
+
+    export type Result<
+        I extends ITaskInput = ITaskInput,
+        O extends ITaskOutput = ITaskOutput
+    > = ITaskResult<I, O>;
+
+    export type LifecycleHookParams<
+        I extends ITaskInput = ITaskInput,
+        O extends ITaskOutput = ITaskOutput
+    > = ITaskLifecycleHook<I, O>;
 }
 
 export namespace TaskDefinition {
@@ -163,6 +232,13 @@ export namespace TaskDefinition {
         I extends ITaskInput = ITaskInput,
         O extends ITaskOutput = ITaskOutput
     > = ITaskDefinition<I, O>;
+
+    export type Metadata = ITaskMetadata;
+
+    export type Handler<
+        I extends ITaskInput = ITaskInput,
+        O extends ITaskOutput = ITaskOutput
+    > = ITaskHandler<I, O>;
 
     export type TaskInput = ITaskInput;
 

--- a/packages/background-tasks/__tests__/decorators/SelfCleaningTaskDecorator.test.ts
+++ b/packages/background-tasks/__tests__/decorators/SelfCleaningTaskDecorator.test.ts
@@ -3,6 +3,7 @@ import { SelfCleaningTaskDecoratorImpl } from "~/api/decorators/SelfCleaningTask
 import { TaskDataStatus } from "~/api/types.js";
 import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import type { CleanupTaskSubtreeUseCase } from "~/api/features/CleanupTaskSubtree/index.js";
+import type { Logger } from "@webiny/api-core/features/logger/index.js";
 import type { ITask } from "~/api/types.js";
 
 const fakeTask = (id = "t1"): ITask =>
@@ -29,6 +30,19 @@ const makeCleanup = () => {
     return { cleanupTaskSubtree, cleaned };
 };
 
+const makeLogger = () => {
+    const errors: unknown[] = [];
+    const logger = {
+        error: (...args: unknown[]) => {
+            errors.push(args);
+        },
+        warn: () => undefined,
+        info: () => undefined,
+        debug: () => undefined
+    } as unknown as Logger.Interface;
+    return { logger, errors };
+};
+
 const makeDefinition = (
     overrides: Partial<TaskDefinition.Interface> = {}
 ): TaskDefinition.Interface =>
@@ -48,6 +62,7 @@ describe("SelfCleaningTaskDecorator", () => {
         it("keeps databaseLogs when selfCleanup is undefined", () => {
             const dec = new SelfCleaningTaskDecoratorImpl(
                 noopCleanup,
+                makeLogger().logger,
                 makeDefinition({ databaseLogs: true })
             );
             expect(dec.databaseLogs).toBe(true);
@@ -56,6 +71,7 @@ describe("SelfCleaningTaskDecorator", () => {
         it("keeps databaseLogs when selfCleanup is 'never'", () => {
             const dec = new SelfCleaningTaskDecoratorImpl(
                 noopCleanup,
+                makeLogger().logger,
                 makeDefinition({ databaseLogs: true, selfCleanup: "never" })
             );
             expect(dec.databaseLogs).toBe(true);
@@ -64,6 +80,7 @@ describe("SelfCleaningTaskDecorator", () => {
         it("forces databaseLogs=false when selfCleanup is a single event", () => {
             const dec = new SelfCleaningTaskDecoratorImpl(
                 noopCleanup,
+                makeLogger().logger,
                 makeDefinition({ databaseLogs: true, selfCleanup: "onSuccess" })
             );
             expect(dec.databaseLogs).toBe(false);
@@ -72,6 +89,7 @@ describe("SelfCleaningTaskDecorator", () => {
         it("forces databaseLogs=false when selfCleanup is an array", () => {
             const dec = new SelfCleaningTaskDecoratorImpl(
                 noopCleanup,
+                makeLogger().logger,
                 makeDefinition({
                     databaseLogs: true,
                     selfCleanup: ["onSuccess", "onError"]
@@ -83,6 +101,7 @@ describe("SelfCleaningTaskDecorator", () => {
         it("forces databaseLogs=false when selfCleanup is 'always'", () => {
             const dec = new SelfCleaningTaskDecoratorImpl(
                 noopCleanup,
+                makeLogger().logger,
                 makeDefinition({ databaseLogs: true, selfCleanup: "always" })
             );
             expect(dec.databaseLogs).toBe(false);
@@ -91,7 +110,11 @@ describe("SelfCleaningTaskDecorator", () => {
 
     describe("hook exposure", () => {
         it("always exposes onDone / onError / onAbort even if the decoratee has none", () => {
-            const dec = new SelfCleaningTaskDecoratorImpl(noopCleanup, makeDefinition());
+            const dec = new SelfCleaningTaskDecoratorImpl(
+                noopCleanup,
+                makeLogger().logger,
+                makeDefinition()
+            );
             expect(typeof dec.onDone).toBe("function");
             expect(typeof dec.onError).toBe("function");
             expect(typeof dec.onAbort).toBe("function");
@@ -103,6 +126,7 @@ describe("SelfCleaningTaskDecorator", () => {
             const { cleanupTaskSubtree, cleaned } = makeCleanup();
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({ selfCleanup: "onError" })
             );
             await dec.onDone!({ task: fakeTask() });
@@ -113,6 +137,7 @@ describe("SelfCleaningTaskDecorator", () => {
             const { cleanupTaskSubtree, cleaned } = makeCleanup();
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({ selfCleanup: "onSuccess" })
             );
             await dec.onDone!({ task: fakeTask("t42") });
@@ -123,6 +148,7 @@ describe("SelfCleaningTaskDecorator", () => {
             const { cleanupTaskSubtree, cleaned } = makeCleanup();
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({ selfCleanup: ["onError"] })
             );
             await dec.onError!({ task: fakeTask("t1") });
@@ -133,6 +159,7 @@ describe("SelfCleaningTaskDecorator", () => {
             const { cleanupTaskSubtree, cleaned } = makeCleanup();
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({ selfCleanup: "always" })
             );
             await dec.onAbort!({ task: fakeTask() });
@@ -150,6 +177,7 @@ describe("SelfCleaningTaskDecorator", () => {
             };
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({
                     selfCleanup: "onSuccess",
                     onDone: async () => {
@@ -166,6 +194,7 @@ describe("SelfCleaningTaskDecorator", () => {
             const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
             const dec = new SelfCleaningTaskDecoratorImpl(
                 cleanupTaskSubtree,
+                makeLogger().logger,
                 makeDefinition({
                     selfCleanup: "onSuccess",
                     onDone: async () => {

--- a/packages/background-tasks/__tests__/features/GetTaskDefinitionUseCase.test.ts
+++ b/packages/background-tasks/__tests__/features/GetTaskDefinitionUseCase.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from "vitest";
 import type { Constructor } from "@webiny/di";
 import { GetTaskDefinitionUseCaseImpl } from "~/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.js";
-import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
+import {
+    TaskDefinition,
+    TaskHandler
+} from "@webiny/api-core/features/task/TaskDefinition/index.js";
+import type { Logger } from "@webiny/api-core/features/logger/index.js";
 import type { TaskHandlerResolver } from "~/api/features/TaskHandlerResolver/index.js";
 
 /**
  * Records which handler classes were actually built, so a test can assert that looking up one task
- * does not construct the other 28.
+ * does not construct the others.
  */
 const makeResolver = () => {
     const resolved: string[] = [];
@@ -19,24 +23,53 @@ const makeResolver = () => {
     return { resolver, resolved };
 };
 
-const useCaseOf = (
-    definitions: TaskDefinition.Interface[],
-    resolver: TaskHandlerResolver.Interface
-) => {
-    return new GetTaskDefinitionUseCaseImpl(definitions, resolver);
+const makeLogger = () => {
+    const errors: unknown[] = [];
+    const logger = {
+        error: (...args: unknown[]) => {
+            errors.push(args);
+        },
+        warn: () => undefined,
+        info: () => undefined,
+        debug: () => undefined
+    } as unknown as Logger.Interface;
+    return { logger, errors };
 };
 
-class GreetHandler implements TaskDefinition.Handler {
+const useCaseOf = (
+    definitions: TaskDefinition.Interface[],
+    resolver: TaskHandlerResolver.Interface,
+    logger: Logger.Interface = makeLogger().logger
+) => {
+    return new GetTaskDefinitionUseCaseImpl(definitions, resolver, logger);
+};
+
+/**
+ * Handlers go through `createImplementation` because that is what production requires:
+ * `resolveImplementation` reads dependency metadata off the class and throws
+ * "No abstraction metadata found" for a plain one.
+ */
+class GreetHandlerImpl implements TaskHandler.Interface {
     async run() {
         return { status: "done", output: { greeted: true } } as any;
     }
 }
 
-class NeverBuiltHandler implements TaskDefinition.Handler {
+const GreetHandler = TaskHandler.createImplementation({
+    implementation: GreetHandlerImpl,
+    dependencies: []
+});
+
+class NeverBuiltHandlerImpl implements TaskHandler.Interface {
     async run() {
         return { status: "done" } as any;
     }
 }
+
+const NeverBuiltHandler = TaskHandler.createImplementation({
+    implementation: NeverBuiltHandlerImpl,
+    dependencies: []
+});
 
 const greet: TaskDefinition.Interface = {
     id: "greet",
@@ -57,7 +90,7 @@ describe("GetTaskDefinitionUseCase", () => {
         const result = useCaseOf([greet, other], resolver).execute("greet");
 
         expect(result.isOk()).toBe(true);
-        expect(resolved).toEqual(["GreetHandler"]);
+        expect(resolved).toEqual(["GreetHandlerImpl"]);
     });
 
     it("exposes metadata from the definition and behaviour from the handler", async () => {
@@ -109,5 +142,74 @@ describe("GetTaskDefinitionUseCase", () => {
 
         expect(result.isFail()).toBe(true);
         expect(result.error.code).toBe("BackgroundTasks/TaskDefinition/NotFoundError");
+    });
+
+    describe("hook chaining", () => {
+        // A definition-level hook is what a decorator contributes — SelfCleaningTaskDecorator's
+        // onDone is exactly this. Dropping either half would break decoration or the task itself.
+        const makeChained = (onHandlerDone: () => void, onDefinitionDone: () => void) => {
+            class ChainedHandlerImpl implements TaskHandler.Interface {
+                async run() {
+                    return { status: "done" } as any;
+                }
+                async onDone() {
+                    onHandlerDone();
+                }
+            }
+
+            const ChainedHandler = TaskHandler.createImplementation({
+                implementation: ChainedHandlerImpl,
+                dependencies: []
+            });
+
+            return {
+                id: "chained",
+                title: "Chained",
+                handler: ChainedHandler,
+                onDone: async () => {
+                    onDefinitionDone();
+                }
+            } as TaskDefinition.Interface;
+        };
+
+        it("runs the handler's hook before the decorator's", async () => {
+            const calls: string[] = [];
+            const { resolver } = makeResolver();
+            const definition = makeChained(
+                () => calls.push("handler"),
+                () => calls.push("decorator")
+            );
+
+            const result = useCaseOf([definition], resolver).execute("chained");
+            await result.value.onDone!({} as any);
+
+            expect(calls).toEqual(["handler", "decorator"]);
+        });
+
+        it("still runs the decorator's hook when the handler's throws", async () => {
+            const calls: string[] = [];
+            const { resolver } = makeResolver();
+            const { logger, errors } = makeLogger();
+            const definition = makeChained(
+                () => {
+                    throw new Error("boom");
+                },
+                () => calls.push("decorator")
+            );
+
+            const result = useCaseOf([definition], resolver, logger).execute("chained");
+            await result.value.onDone!({} as any);
+
+            expect(calls).toEqual(["decorator"]);
+            expect(errors).toHaveLength(1);
+        });
+
+        it("leaves a hook undefined when neither half defines it", () => {
+            const { resolver } = makeResolver();
+
+            const result = useCaseOf([greet], resolver).execute("greet");
+
+            expect(result.value.onAbort).toBeUndefined();
+        });
     });
 });

--- a/packages/background-tasks/__tests__/features/GetTaskDefinitionUseCase.test.ts
+++ b/packages/background-tasks/__tests__/features/GetTaskDefinitionUseCase.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import type { Constructor } from "@webiny/di";
+import { GetTaskDefinitionUseCaseImpl } from "~/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.js";
+import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
+import type { TaskHandlerResolver } from "~/api/features/TaskHandlerResolver/index.js";
+
+/**
+ * Records which handler classes were actually built, so a test can assert that looking up one task
+ * does not construct the other 28.
+ */
+const makeResolver = () => {
+    const resolved: string[] = [];
+    const resolver: TaskHandlerResolver.Interface = {
+        resolve: (handler: Constructor<any>) => {
+            resolved.push(handler.name);
+            return new handler();
+        }
+    };
+    return { resolver, resolved };
+};
+
+const useCaseOf = (
+    definitions: TaskDefinition.Interface[],
+    resolver: TaskHandlerResolver.Interface
+) => {
+    return new GetTaskDefinitionUseCaseImpl(definitions, resolver);
+};
+
+class GreetHandler implements TaskDefinition.Handler {
+    async run() {
+        return { status: "done", output: { greeted: true } } as any;
+    }
+}
+
+class NeverBuiltHandler implements TaskDefinition.Handler {
+    async run() {
+        return { status: "done" } as any;
+    }
+}
+
+const greet: TaskDefinition.Interface = {
+    id: "greet",
+    title: "Greet",
+    handler: GreetHandler
+};
+
+const other: TaskDefinition.Interface = {
+    id: "other",
+    title: "Other",
+    handler: NeverBuiltHandler
+};
+
+describe("GetTaskDefinitionUseCase", () => {
+    it("builds only the handler of the task being looked up", () => {
+        const { resolver, resolved } = makeResolver();
+
+        const result = useCaseOf([greet, other], resolver).execute("greet");
+
+        expect(result.isOk()).toBe(true);
+        expect(resolved).toEqual(["GreetHandler"]);
+    });
+
+    it("exposes metadata from the definition and behaviour from the handler", async () => {
+        const { resolver } = makeResolver();
+
+        const result = useCaseOf([greet], resolver).execute("greet");
+        const runnable = result.value;
+
+        expect(runnable.id).toBe("greet");
+        expect(runnable.title).toBe("Greet");
+        await expect(runnable.run({} as any)).resolves.toEqual({
+            status: "done",
+            output: { greeted: true }
+        });
+    });
+
+    it("still accepts a definition that carries run() itself", async () => {
+        const { resolver, resolved } = makeResolver();
+        const legacy: TaskDefinition.Interface = {
+            id: "legacy",
+            title: "Legacy",
+            run: async () => ({ status: "done", output: { legacy: true } }) as any
+        };
+
+        const result = useCaseOf([legacy], resolver).execute("legacy");
+
+        expect(result.isOk()).toBe(true);
+        expect(resolved).toEqual([]);
+        await expect(result.value.run({} as any)).resolves.toEqual({
+            status: "done",
+            output: { legacy: true }
+        });
+    });
+
+    it("fails when a definition supplies neither a handler nor run()", () => {
+        const { resolver } = makeResolver();
+        const broken = { id: "broken", title: "Broken" } as TaskDefinition.Interface;
+
+        const result = useCaseOf([broken], resolver).execute("broken");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.code).toBe("BackgroundTasks/TaskDefinition/NotRunnableError");
+    });
+
+    it("fails when no definition matches the id", () => {
+        const { resolver } = makeResolver();
+
+        const result = useCaseOf([greet], resolver).execute("nope");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.code).toBe("BackgroundTasks/TaskDefinition/NotFoundError");
+    });
+});

--- a/packages/background-tasks/src/api/BackgroundTasksFeature.ts
+++ b/packages/background-tasks/src/api/BackgroundTasksFeature.ts
@@ -10,6 +10,7 @@ import { createDefinitionCrud } from "./crud/definition.tasks.js";
 import { createServiceCrud } from "./crud/service.tasks.js";
 import { createTaskCrud } from "./crud/crud.tasks.js";
 import { TaskExecutionContextFeature } from "./features/TaskExecutionContext/feature.js";
+import { TaskHandlerResolverFeature } from "./features/TaskHandlerResolver/feature.js";
 import { GetTaskDefinitionFeature } from "./features/GetTaskDefinition/feature.js";
 import { ListTaskDefinitionsFeature } from "./features/ListTaskDefinitions/feature.js";
 import {
@@ -41,6 +42,7 @@ export const BackgroundTasksFeature = createFeature({
         container.registerDecorator(SelfCleaningTaskDecorator);
 
         // Task definition use cases.
+        TaskHandlerResolverFeature.register(container);
         GetTaskDefinitionFeature.register(container);
         ListTaskDefinitionsFeature.register(container);
 

--- a/packages/background-tasks/src/api/decorators/RunnableTaskDecorator.ts
+++ b/packages/background-tasks/src/api/decorators/RunnableTaskDecorator.ts
@@ -50,9 +50,15 @@ class RunnableTaskDecoratorImpl implements TaskDefinition.Interface {
         return this.decoratee.createInputValidation;
     }
 
+    // A definition that delegates to a `handler` class has no `run` of its own — the handler
+    // supplies it, and GetTaskDefinitionUseCase merges the two halves after this decorator runs.
+    get handler() {
+        return this.decoratee.handler;
+    }
+
     // Delegate lifecycle methods (bind to preserve context)
     get run() {
-        return this.decoratee.run.bind(this.decoratee);
+        return this.decoratee.run?.bind(this.decoratee);
     }
 
     get onBeforeTrigger() {
@@ -78,9 +84,9 @@ class RunnableTaskDecoratorImpl implements TaskDefinition.Interface {
     // Validation logic
     private validate(): void {
         if (camelCase(this.decoratee.id) !== this.decoratee.id) {
-            const message = `Task ID "${this.decoratee.id}" is invalid. It must be in camelCase format, for example: "myCustomTask".`;
-            console.log(message);
-            throw new WebinyError(message);
+            throw new WebinyError(
+                `Task ID "${this.decoratee.id}" is invalid. It must be in camelCase format, for example: "myCustomTask".`
+            );
         }
     }
 

--- a/packages/background-tasks/src/api/decorators/SelfCleaningTaskDecorator.ts
+++ b/packages/background-tasks/src/api/decorators/SelfCleaningTaskDecorator.ts
@@ -1,4 +1,5 @@
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import type { ISelfCleanupEvent } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import { normalizeSelfCleanup } from "~/api/utils/normalizeSelfCleanup.js";
 import { CleanupTaskSubtreeUseCase } from "~/api/features/CleanupTaskSubtree/index.js";
@@ -12,9 +13,15 @@ export class SelfCleaningTaskDecoratorImpl implements TaskDefinition.Interface {
 
     public constructor(
         private readonly cleanupTaskSubtree: CleanupTaskSubtreeUseCase.Interface,
+        private readonly logger: Logger.Interface,
         private decoratee: TaskDefinition.Interface
     ) {
         this.events = normalizeSelfCleanup(decoratee.selfCleanup);
+    }
+
+    // A definition that delegates to a `handler` class has no `run` of its own.
+    get handler() {
+        return this.decoratee.handler;
     }
 
     // Pass-through properties.
@@ -40,7 +47,7 @@ export class SelfCleaningTaskDecoratorImpl implements TaskDefinition.Interface {
         return this.decoratee.createInputValidation;
     }
     get run() {
-        return this.decoratee.run.bind(this.decoratee);
+        return this.decoratee.run?.bind(this.decoratee);
     }
     get onBeforeTrigger() {
         return this.decoratee.onBeforeTrigger?.bind(this.decoratee);
@@ -101,13 +108,15 @@ export class SelfCleaningTaskDecoratorImpl implements TaskDefinition.Interface {
         try {
             await hook.call(this.decoratee, params);
         } catch (ex) {
-            console.error(`Error executing ${name} hook for task "${params.task.id}".`);
-            console.log(getErrorProperties(ex));
+            this.logger.error(
+                { error: getErrorProperties(ex), taskId: params.task.id, hook: name },
+                "Error executing task lifecycle hook."
+            );
         }
     }
 }
 
 export const SelfCleaningTaskDecorator = TaskDefinition.createDecorator({
     decorator: SelfCleaningTaskDecoratorImpl,
-    dependencies: [CleanupTaskSubtreeUseCase]
+    dependencies: [CleanupTaskSubtreeUseCase, Logger]
 });

--- a/packages/background-tasks/src/api/domain/errors.ts
+++ b/packages/background-tasks/src/api/domain/errors.ts
@@ -16,6 +16,23 @@ export class TaskDefinitionNotFoundError extends BaseError<{ id: string }> {
     }
 }
 
+/**
+ * A definition was found by id but supplies no behaviour: neither a `handler` class nor its own
+ * `run()`. Only reachable while definitions are migrating from one shape to the other.
+ */
+export class TaskDefinitionNotRunnableError extends BaseError<{ id: string }> {
+    override readonly code = "BackgroundTasks/TaskDefinition/NotRunnableError" as const;
+
+    constructor(id: string) {
+        super({
+            message: `Task definition "${id}" defines neither a "handler" nor a "run" method.`,
+            data: {
+                id
+            }
+        });
+    }
+}
+
 export class TaskNotFoundError extends BaseError {
     override readonly code = "BackgroundTasks/Task/NotFoundError" as const;
 

--- a/packages/background-tasks/src/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.ts
+++ b/packages/background-tasks/src/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.ts
@@ -1,26 +1,81 @@
 import { Result } from "@webiny/feature/api";
+import type { Constructor } from "@webiny/di";
 import { GetTaskDefinitionUseCase as UseCaseAbstraction } from "./abstractions.js";
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
-import { TaskDefinitionNotFoundError } from "~/api/domain/errors.js";
+import { TaskHandlerResolver } from "~/api/features/TaskHandlerResolver/index.js";
+import {
+    TaskDefinitionNotFoundError,
+    TaskDefinitionNotRunnableError
+} from "~/api/domain/errors.js";
 
-class GetTaskDefinitionUseCaseImpl implements UseCaseAbstraction.Interface {
-    public constructor(private definitions: TaskDefinition.Interface[]) {}
+export class GetTaskDefinitionUseCaseImpl implements UseCaseAbstraction.Interface {
+    public constructor(
+        private definitions: TaskDefinition.Interface[],
+        private handlerResolver: TaskHandlerResolver.Interface
+    ) {}
 
     public execute<
         I extends TaskDefinition.TaskInput = TaskDefinition.TaskInput,
         O extends TaskDefinition.TaskOutput = TaskDefinition.TaskOutput
     >(id: string): Result<TaskDefinition.Runnable<I, O>, UseCaseAbstraction.Error> {
         for (const definition of this.definitions) {
-            if (definition.id === id) {
+            if (definition.id !== id) {
+                continue;
+            }
+
+            // New shape: the definition names a handler class, built only now that we know this is
+            // the task being asked for. Its dependencies are never touched for the other 28.
+            if (definition.handler) {
+                // The registered definition is stored under the abstraction's default generics, so
+                // its handler cannot be proven assignable to the caller's narrower <I, O>. Same
+                // reason the legacy branch below casts.
+                const handler = this.handlerResolver.resolve(
+                    definition.handler as Constructor<TaskDefinition.Handler<I, O>>
+                );
+                return Result.ok(toRunnable<I, O>(definition, handler));
+            }
+
+            // Old shape: the definition carries `run()` and the hooks itself, so it IS the handler.
+            if (typeof definition.run === "function") {
                 return Result.ok(definition as TaskDefinition.Runnable<I, O>);
             }
+
+            return Result.fail(new TaskDefinitionNotRunnableError(id));
         }
 
         return Result.fail(new TaskDefinitionNotFoundError(id));
     }
 }
 
+/**
+ * Present the two halves as the single object the runner and `context.tasks.getDefinition()` expect.
+ * Metadata reads come from the definition, behaviour from the handler, bound so `this` inside a hook
+ * is still the handler instance that owns the injected dependencies.
+ */
+const toRunnable = <I extends TaskDefinition.TaskInput, O extends TaskDefinition.TaskOutput>(
+    definition: TaskDefinition.Interface,
+    handler: TaskDefinition.Handler<I, O>
+): TaskDefinition.Runnable<I, O> => {
+    return {
+        id: definition.id,
+        title: definition.title,
+        description: definition.description,
+        isPrivate: definition.isPrivate as boolean,
+        databaseLogs: definition.databaseLogs as boolean,
+        maxIterations: definition.maxIterations as number,
+        selfCleanup: definition.selfCleanup,
+
+        run: handler.run.bind(handler),
+        onBeforeTrigger: handler.onBeforeTrigger?.bind(handler),
+        onDone: handler.onDone?.bind(handler),
+        onError: handler.onError?.bind(handler),
+        onAbort: handler.onAbort?.bind(handler),
+        onMaxIterations: handler.onMaxIterations?.bind(handler),
+        createInputValidation: handler.createInputValidation?.bind(handler)
+    };
+};
+
 export const GetTaskDefinitionUseCase = UseCaseAbstraction.createImplementation({
     implementation: GetTaskDefinitionUseCaseImpl,
-    dependencies: [[TaskDefinition, { multiple: true }]]
+    dependencies: [[TaskDefinition, { multiple: true }], TaskHandlerResolver]
 });

--- a/packages/background-tasks/src/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.ts
+++ b/packages/background-tasks/src/api/features/GetTaskDefinition/GetTaskDefinitionUseCase.ts
@@ -3,6 +3,7 @@ import type { Constructor } from "@webiny/di";
 import { GetTaskDefinitionUseCase as UseCaseAbstraction } from "./abstractions.js";
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import { TaskHandlerResolver } from "~/api/features/TaskHandlerResolver/index.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import {
     TaskDefinitionNotFoundError,
     TaskDefinitionNotRunnableError
@@ -11,7 +12,8 @@ import {
 export class GetTaskDefinitionUseCaseImpl implements UseCaseAbstraction.Interface {
     public constructor(
         private definitions: TaskDefinition.Interface[],
-        private handlerResolver: TaskHandlerResolver.Interface
+        private handlerResolver: TaskHandlerResolver.Interface,
+        private logger: Logger.Interface
     ) {}
 
     public execute<
@@ -32,7 +34,7 @@ export class GetTaskDefinitionUseCaseImpl implements UseCaseAbstraction.Interfac
                 const handler = this.handlerResolver.resolve(
                     definition.handler as Constructor<TaskDefinition.Handler<I, O>>
                 );
-                return Result.ok(toRunnable<I, O>(definition, handler));
+                return Result.ok(toRunnable<I, O>(definition, handler, this.logger));
             }
 
             // Old shape: the definition carries `run()` and the hooks itself, so it IS the handler.
@@ -47,15 +49,48 @@ export class GetTaskDefinitionUseCaseImpl implements UseCaseAbstraction.Interfac
     }
 }
 
+type HookName = "onBeforeTrigger" | "onDone" | "onError" | "onAbort" | "onMaxIterations";
+
 /**
  * Present the two halves as the single object the runner and `context.tasks.getDefinition()` expect.
- * Metadata reads come from the definition, behaviour from the handler, bound so `this` inside a hook
- * is still the handler instance that owns the injected dependencies.
+ * Metadata reads come from the definition, behaviour from the handler.
+ *
+ * Hooks come from BOTH, in that order, because they mean different things. The handler's hook is the
+ * task author's, and the definition's is whatever a decorator added: `SelfCleaningTaskDecorator`
+ * supplies an `onDone` that deletes the finished task. Taking only the handler's would silently drop
+ * every definition-level decorator, and taking only the definition's would drop the task's own.
+ *
+ * The handler's hook is guarded so a throwing user hook still lets the decorator's half run, which is
+ * what the old single-object implementation did via its own `safeCall`.
  */
 const toRunnable = <I extends TaskDefinition.TaskInput, O extends TaskDefinition.TaskOutput>(
     definition: TaskDefinition.Interface,
-    handler: TaskDefinition.Handler<I, O>
+    handler: TaskDefinition.Handler<I, O>,
+    logger: Logger.Interface
 ): TaskDefinition.Runnable<I, O> => {
+    const chain = (name: HookName) => {
+        const own = handler[name]?.bind(handler);
+        const decorated = definition[name]?.bind(definition);
+
+        if (!own && !decorated) {
+            return undefined;
+        }
+
+        return async (params: any) => {
+            if (own) {
+                try {
+                    await own(params);
+                } catch (error) {
+                    logger.error(
+                        { error, taskId: definition.id, hook: name },
+                        "Error executing task lifecycle hook."
+                    );
+                }
+            }
+            await decorated?.(params);
+        };
+    };
+
     return {
         id: definition.id,
         title: definition.title,
@@ -66,16 +101,16 @@ const toRunnable = <I extends TaskDefinition.TaskInput, O extends TaskDefinition
         selfCleanup: definition.selfCleanup,
 
         run: handler.run.bind(handler),
-        onBeforeTrigger: handler.onBeforeTrigger?.bind(handler),
-        onDone: handler.onDone?.bind(handler),
-        onError: handler.onError?.bind(handler),
-        onAbort: handler.onAbort?.bind(handler),
-        onMaxIterations: handler.onMaxIterations?.bind(handler),
+        onBeforeTrigger: chain("onBeforeTrigger"),
+        onDone: chain("onDone"),
+        onError: chain("onError"),
+        onAbort: chain("onAbort"),
+        onMaxIterations: chain("onMaxIterations"),
         createInputValidation: handler.createInputValidation?.bind(handler)
     };
 };
 
 export const GetTaskDefinitionUseCase = UseCaseAbstraction.createImplementation({
     implementation: GetTaskDefinitionUseCaseImpl,
-    dependencies: [[TaskDefinition, { multiple: true }], TaskHandlerResolver]
+    dependencies: [[TaskDefinition, { multiple: true }], TaskHandlerResolver, Logger]
 });

--- a/packages/background-tasks/src/api/features/GetTaskDefinition/abstractions.ts
+++ b/packages/background-tasks/src/api/features/GetTaskDefinition/abstractions.ts
@@ -1,7 +1,10 @@
 import { createAbstraction } from "@webiny/feature/api";
 import type { Result } from "@webiny/feature/api";
 import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
-import type { TaskDefinitionNotFoundError } from "~/api/domain/errors.js";
+import type {
+    TaskDefinitionNotFoundError,
+    TaskDefinitionNotRunnableError
+} from "~/api/domain/errors.js";
 
 export interface IGetTaskDefinitionUseCase {
     execute<
@@ -14,6 +17,7 @@ export interface IGetTaskDefinitionUseCase {
 
 export interface IGetTaskDefinitionUseCaseErrors {
     notFound: TaskDefinitionNotFoundError;
+    notRunnable: TaskDefinitionNotRunnableError;
 }
 
 type UseCaseError = IGetTaskDefinitionUseCaseErrors[keyof IGetTaskDefinitionUseCaseErrors];

--- a/packages/background-tasks/src/api/features/TaskHandlerResolver/TaskHandlerResolver.ts
+++ b/packages/background-tasks/src/api/features/TaskHandlerResolver/TaskHandlerResolver.ts
@@ -1,0 +1,24 @@
+import type { Container, Constructor } from "@webiny/di";
+import { RequestContainer } from "@webiny/event-handler-core/features/events/RequestContainer.js";
+import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
+import { TaskHandlerResolver as Abstraction } from "./abstractions.js";
+
+class ContainerTaskHandlerResolver implements Abstraction.Interface {
+    public constructor(private readonly container: Container) {}
+
+    public resolve<
+        I extends TaskDefinition.TaskInput = TaskDefinition.TaskInput,
+        O extends TaskDefinition.TaskOutput = TaskDefinition.TaskOutput
+    >(handler: Constructor<TaskDefinition.Handler<I, O>>): TaskDefinition.Handler<I, O> {
+        // `resolveImplementation` builds the class from its own dependency metadata and runs it
+        // through the normal resolution path, so decorators registered against the handler still
+        // apply. It deliberately ignores registrations, which is what we want here: the definition
+        // names the class directly and nothing registers handlers against an abstraction.
+        return this.container.resolveImplementation(handler);
+    }
+}
+
+export const TaskHandlerResolver = Abstraction.createImplementation({
+    implementation: ContainerTaskHandlerResolver,
+    dependencies: [RequestContainer]
+});

--- a/packages/background-tasks/src/api/features/TaskHandlerResolver/abstractions.ts
+++ b/packages/background-tasks/src/api/features/TaskHandlerResolver/abstractions.ts
@@ -1,0 +1,28 @@
+import { createAbstraction } from "@webiny/feature/api";
+import type { Constructor } from "@webiny/di";
+import type { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
+
+export interface ITaskHandlerResolver {
+    resolve<
+        I extends TaskDefinition.TaskInput = TaskDefinition.TaskInput,
+        O extends TaskDefinition.TaskOutput = TaskDefinition.TaskOutput
+    >(
+        handler: Constructor<TaskDefinition.Handler<I, O>>
+    ): TaskDefinition.Handler<I, O>;
+}
+
+/**
+ * Builds the behaviour half of a task on demand.
+ *
+ * Something has to turn `definition.handler` (a class) into an instance, and that needs the
+ * container. Rather than injecting the container into a use case — which is the service-locator
+ * pattern we keep out of DI classes — it lives behind this one narrow abstraction. Everything else
+ * depends on `resolve(handler)` and stays testable with a stub.
+ */
+export const TaskHandlerResolver = createAbstraction<ITaskHandlerResolver>(
+    "Tasks/TaskHandlerResolver"
+);
+
+export namespace TaskHandlerResolver {
+    export type Interface = ITaskHandlerResolver;
+}

--- a/packages/background-tasks/src/api/features/TaskHandlerResolver/feature.ts
+++ b/packages/background-tasks/src/api/features/TaskHandlerResolver/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import { TaskHandlerResolver } from "./TaskHandlerResolver.js";
+
+export const TaskHandlerResolverFeature = createFeature({
+    name: "TaskHandlerResolver",
+    register(container) {
+        container.register(TaskHandlerResolver);
+    }
+});

--- a/packages/background-tasks/src/api/features/TaskHandlerResolver/index.ts
+++ b/packages/background-tasks/src/api/features/TaskHandlerResolver/index.ts
@@ -1,0 +1,2 @@
+export { TaskHandlerResolver } from "./abstractions.js";
+export { TaskHandlerResolverFeature } from "./feature.js";


### PR DESCRIPTION
First of six. Ships the mechanism, migrates nothing, changes no behaviour.

## The problem

`GetTaskDefinitionUseCase` finds one task by looping every registered definition and comparing `definition.id`. There are 24 of them, and a definition carries its dependencies:

```ts
export const MockDataManagerTaskDefinition = TaskDefinition.createImplementation({
    implementation: MockDataManagerTask,
    dependencies: [CmsContext, OpenSearchClient, CmsModelOpenSearchIndexProvider]
});
```

So looking up any task builds a CMS context, an OpenSearch client and an index provider, 24 times over, for the 23 you didn't ask for.

This is the same shape #5668 fixed for HTTP routes, and worse in one way. The injection is a constructor parameter:

```ts
dependencies: [[TaskDefinition, { multiple: true }]]
```

`HttpRouter` at least resolved inside `route()`, so the cost landed per request. Here the whole set is built when the use case itself is constructed, whether or not anything ever looks a task up.

## The split

Mirrors `HttpRouteDefinition` / `HttpRouteHandler`:

| | carries | built |
|---|---|---|
| `ITaskMetadata` | id, title, description, maxIterations, databaseLogs, isPrivate, selfCleanup | always, but it has no dependencies |
| `ITaskHandler` | `run()` and the lifecycle hooks | only for the task being run |

A definition points at its handler class, and the use case resolves that one handler once it knows which task was asked for.

### Why the hooks went with the handler

The code answers this one. `MockDataManagerTask.onError` and `onAbort` both use `this.openSearchClient` and `this.indexProvider`, the same dependencies injected for `run()`. The hooks need what the handler needs, so they live with it and metadata stays dependency-free.

### Why a resolver instead of injecting the container

Something has to turn `definition.handler` into an instance, and that needs the container. Injecting a container into a use case is the service-locator pattern we keep out of DI classes, so it sits behind one narrow abstraction instead:

```ts
export interface ITaskHandlerResolver {
    resolve<I, O>(handler: Constructor<TaskDefinition.Handler<I, O>>): TaskDefinition.Handler<I, O>;
}
```

One infrastructure class holds the container. Everything else depends on `resolve(handler)` and stays stubbable, which is exactly what the tests do.

A handler must be a `createImplementation` result, not a bare class. `resolveImplementation` reads dependency metadata off the class:

```
RawZero:     THROWS -> No abstraction metadata found for RawZero
RawWithDep:  THROWS -> No abstraction metadata found for RawWithDep
Proper:      ok -> 42
```

### Why hooks chain instead of coming from one side

`toRunnable` composes hooks from BOTH halves, handler first and definition second, because they mean different things. The handler's is the task author's. The definition's is whatever a decorator added, and `SelfCleaningTaskDecorator` contributes exactly that: an `onDone` that deletes the finished task.

Taking only the handler's would silently drop every definition-level decorator. Taking only the definition's would drop the task's own. The handler half is guarded, so a throwing user hook still lets the decorator's half run, matching what the old single-object implementation did with its own `safeCall`.

This also answers a question I had left open here: whether `SelfCleaningTaskDecorator` should become a handler decorator that looks metadata up by `definitionId`, or whether self-cleanup should move into the runner. Neither. Composing both halves where they already meet keeps `selfCleanup` extensible by decoration and leaves the decorator untouched.

## Transitional shape

`run` is optional on `ITaskDefinition` so both shapes coexist while packages migrate. A definition with neither `run` nor `handler` fails with `TaskDefinitionNotRunnableError` rather than a `TypeError` somewhere downstream.

The optionality is temporary and goes away in the last PR of the series, once all 24 carry a handler. It is called out in the interface doc comment so nobody takes it as the intended design.

## Also

Removed three `console.*` calls from `RunnableTaskDecorator` and `SelfCleaningTaskDecorator`, against the rule that backend code injects the DI `Logger`. Both files were being rewritten anyway.

## Verification

- 96 background-tasks tests, 181 api-core, 139 webhooks, all passing
- all 11 packages that declare task definitions build, plus api-core and background-tasks
- `adio`, `oxlint`, `oxfmt --check` clean

Eight new tests. The two that carry the most weight: one registers two handler-based definitions and asserts that looking up `greet` builds `GreetHandler` and nothing else; another asserts a throwing handler hook still lets the decorator's half run.

## What's next

| PR | scope | definitions |
|---|---|---|
| this | mechanism | 0 |
| #5692 | background-tasks | 1 + fixtures |
| 3 | bulk-actions, cms-tasks, cms-es-tasks, search-index-tasks | 8 |
| 4 | fm-s3, fm-server, api-aco | 9 |
| 5 | ai-powerups, remote-components, webhooks, website-builder | 7 |
| 6 | remove compat, drop both `multiple: true`, fix the `context.container` service locator in `TaskControl` | 0 |

The win accrues per PR rather than landing all at the end: a migrated definition becomes a zero-dependency metadata object, so each package that moves over drops its construction cost out of the lookup path immediately.

## Review note

The second commit fixes two defects in the first one's code, both found while migrating real definitions on top of it: hooks were taken from the handler alone, and the test fixtures used bare classes as handlers. If you read an earlier version of this description, those are the parts that changed, and the counts above are corrected (24 definitions across 11 packages, not 29 across 12; the extra five were test fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for task definitions backed by reusable handler classes.
  - Task handlers can participate in execution, validation, and lifecycle hooks.
  - Existing task definitions using a direct `run()` method remain supported.
  - Added clearer handling for task definitions that cannot be executed.

- **Bug Fixes**
  - Lifecycle-hook failures are logged consistently without interrupting subsequent cleanup hooks.
  - Tasks without a `run()` method are handled safely when a handler is available.

- **Tests**
  - Expanded coverage for handler execution, legacy tasks, hook ordering, errors, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->