### PR TITLE
fix(api-core): resolve team role identifiers instead of storing them verbatim

### DIFF
--- a/packages/api-core/__tests__/security/teams.test.ts
+++ b/packages/api-core/__tests__/security/teams.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from "vitest";
 import { useGqlHandler } from "../useGqlHandler";
 import mocks from "../mocks/securityTeam";
+import roleMocks from "../mocks/securityRole";
 import { createTestWcpLicense } from "@webiny/wcp/testing/createTestWcpLicense";
 import { RoleFactory } from "~/features/security/roles/shared/abstractions.js";
 import { TeamFactory } from "~/features/security/teams/shared/abstractions.js";
@@ -56,13 +57,102 @@ const testTeamFactory = TeamFactory.createImplementation({
 });
 
 describe("Security Team CRUD Test", () => {
-    const { install, securityTeam } = useGqlHandler({
+    const { install, securityTeam, securityRole } = useGqlHandler({
         wcpLicense: createTestWcpLicense(),
         registrations: [testRoleFactory, testTeamFactory]
     });
 
     beforeEach(async () => {
         await install.install();
+    });
+
+    /*
+     * A team stores role IDs, and only IDs: GetPermissionsFromIdentity resolves them with `id_in`.
+     * A slug stored there matches nothing, so the team is created, reads correctly, and grants no
+     * permissions. These use a DATABASE role on purpose, because a plugin role gets `id: slug`
+     * (RoleProvider) and so cannot tell the two apart.
+     */
+    describe("role identifiers", () => {
+        const createDatabaseRole = async () => {
+            const [response] = await securityRole.create({ data: roleMocks.roleA });
+            const role = response.data.security.createRole.data;
+
+            // The premise of all of this: for a database role the two differ.
+            expect(role.id).not.toEqual(role.slug);
+
+            return role;
+        };
+
+        test("should accept a role slug and store the role id", async () => {
+            const role = await createDatabaseRole();
+
+            const [response] = await securityTeam.create({
+                data: { ...mocks.teamA, roles: [role.slug] }
+            });
+
+            expect(response.data.security.createTeam.error).toBeNull();
+            expect(response.data.security.createTeam.data.roles.map((r: any) => r.id)).toEqual([
+                role.id
+            ]);
+        });
+
+        test("should accept a role id unchanged", async () => {
+            const role = await createDatabaseRole();
+
+            const [response] = await securityTeam.create({
+                data: { ...mocks.teamA, roles: [role.id] }
+            });
+
+            expect(response.data.security.createTeam.data.roles.map((r: any) => r.id)).toEqual([
+                role.id
+            ]);
+        });
+
+        test("should reject an identifier that is neither an id nor a slug", async () => {
+            const [response] = await securityTeam.create({
+                data: { ...mocks.teamA, roles: ["not-a-role"] }
+            });
+
+            expect(response.data.security.createTeam.data).toBeNull();
+            expect(response.data.security.createTeam.error.message).toMatch(
+                /Not a known role id or slug: "not-a-role"/
+            );
+        });
+
+        test("should resolve a slug on update too", async () => {
+            const role = await createDatabaseRole();
+
+            const [createResponse] = await securityTeam.create({ data: mocks.teamA });
+            const team = createResponse.data.security.createTeam.data;
+
+            const [response] = await securityTeam.update({
+                id: team.id,
+                data: { roles: [role.slug] }
+            });
+
+            expect(response.data.security.updateTeam.error).toBeNull();
+            expect(response.data.security.updateTeam.data.roles.map((r: any) => r.id)).toEqual([
+                role.id
+            ]);
+        });
+
+        test("should leave stored roles alone when an update omits them", async () => {
+            const role = await createDatabaseRole();
+
+            const [createResponse] = await securityTeam.create({
+                data: { ...mocks.teamA, roles: [role.slug] }
+            });
+            const team = createResponse.data.security.createTeam.data;
+
+            const [response] = await securityTeam.update({
+                id: team.id,
+                data: { name: "Renamed" }
+            });
+
+            expect(response.data.security.updateTeam.data.roles.map((r: any) => r.id)).toEqual([
+                role.id
+            ]);
+        });
     });
 
     test("should able to create, read, update and delete `Security Teams`", async () => {

--- a/packages/api-core/src/features/security/teams/CreateTeam/CreateTeamUseCase.ts
+++ b/packages/api-core/src/features/security/teams/CreateTeam/CreateTeamUseCase.ts
@@ -4,18 +4,21 @@ import { Result } from "@webiny/feature/api";
 import { EventPublisher } from "~/features/eventPublisher/index.js";
 import { CreateTeam } from "./abstractions.js";
 import { TeamsRepository } from "../shared/abstractions.js";
+import { RolesRepository } from "../../roles/shared/abstractions.js";
 import { IdentityContext } from "../../IdentityContext/abstractions.js";
 import { createTeamValidation } from "./schema.js";
 import { TeamBeforeCreateEvent, TeamAfterCreateEvent } from "./events.js";
 import type { Team, CreateTeamInput } from "../shared/types.js";
 import { NotAuthorizedError, TeamExistsError, TeamValidationError } from "../shared/errors.js";
 import { descriptionOnCreate } from "../../shared/description.js";
+import { resolveRoleIdentifiers } from "../shared/resolveRoleIdentifiers.js";
 
 export class CreateTeamUseCase implements CreateTeam.Interface {
     constructor(
         private identityContext: IdentityContext.Interface,
         private eventPublisher: EventPublisher.Interface,
-        private repository: TeamsRepository.Interface
+        private repository: TeamsRepository.Interface,
+        private rolesRepository: RolesRepository.Interface
     ) {}
 
     async execute(input: CreateTeamInput): Promise<Result<Team, CreateTeam.Error>> {
@@ -39,10 +42,19 @@ export class CreateTeamUseCase implements CreateTeam.Interface {
             return Result.fail(new TeamExistsError(data.slug));
         }
 
+        // A slug here would be stored verbatim and then match no role, leaving a team that grants
+        // nothing. Resolved before the entity is built so the events carry the stored IDs.
+        const roleIdsResult = await resolveRoleIdentifiers(this.rolesRepository, data.roles);
+
+        if (roleIdsResult.isFail()) {
+            return Result.fail(roleIdsResult.error);
+        }
+
         // Normalised up front so that null reaches neither the entity nor the published events.
         const createInput: CreateTeamInput = {
             ...data,
-            description: descriptionOnCreate(data.description)
+            description: descriptionOnCreate(data.description),
+            roles: roleIdsResult.value
         };
 
         const team: Team = {
@@ -78,5 +90,5 @@ export class CreateTeamUseCase implements CreateTeam.Interface {
 export const CreateTeamUseCaseImpl = createImplementation({
     abstraction: CreateTeam,
     implementation: CreateTeamUseCase,
-    dependencies: [IdentityContext, EventPublisher, TeamsRepository]
+    dependencies: [IdentityContext, EventPublisher, TeamsRepository, RolesRepository]
 });

--- a/packages/api-core/src/features/security/teams/UpdateTeam/UpdateTeamUseCase.ts
+++ b/packages/api-core/src/features/security/teams/UpdateTeam/UpdateTeamUseCase.ts
@@ -2,12 +2,14 @@ import { createImplementation } from "@webiny/feature/api";
 import { Result } from "@webiny/feature/api";
 import { UpdateTeam } from "./abstractions.js";
 import { TeamsRepository } from "../shared/abstractions.js";
+import { RolesRepository } from "../../roles/shared/abstractions.js";
 import { IdentityContext } from "../../IdentityContext/abstractions.js";
 import { EventPublisher } from "~/features/eventPublisher/index.js";
 import { updateTeamValidation } from "./schema.js";
 import { TeamBeforeUpdateEvent, TeamAfterUpdateEvent } from "./events.js";
 import type { Team, UpdateTeamInput } from "../shared/types.js";
 import { descriptionOnUpdate } from "../../shared/description.js";
+import { resolveRoleIdentifiers } from "../shared/resolveRoleIdentifiers.js";
 import {
     NotAuthorizedError,
     CannotUpdatePluginTeamsError,
@@ -19,15 +21,18 @@ export class UpdateTeamUseCase {
     private repository: TeamsRepository.Interface;
     private identityContext: IdentityContext.Interface;
     private eventPublisher: EventPublisher.Interface;
+    private rolesRepository: RolesRepository.Interface;
 
     constructor(
         repository: TeamsRepository.Interface,
         identityContext: IdentityContext.Interface,
-        eventPublisher: EventPublisher.Interface
+        eventPublisher: EventPublisher.Interface,
+        rolesRepository: RolesRepository.Interface
     ) {
         this.repository = repository;
         this.identityContext = identityContext;
         this.eventPublisher = eventPublisher;
+        this.rolesRepository = rolesRepository;
     }
 
     async execute(id: string, input: UpdateTeamInput): Promise<Result<Team, UpdateTeam.Error>> {
@@ -68,6 +73,20 @@ export class UpdateTeamUseCase {
             ...descriptionOnUpdate(description)
         };
 
+        /*
+         * Only when the update mentions roles. An update that omits them must leave the stored ones
+         * alone, and resolving an absent list would cost a read and write an empty array.
+         */
+        if (changes.roles) {
+            const roleIdsResult = await resolveRoleIdentifiers(this.rolesRepository, changes.roles);
+
+            if (roleIdsResult.isFail()) {
+                return Result.fail(roleIdsResult.error);
+            }
+
+            changes.roles = roleIdsResult.value;
+        }
+
         const updatedTeam: Team = {
             ...existingTeam,
             ...changes
@@ -102,5 +121,5 @@ export class UpdateTeamUseCase {
 export const UpdateTeamUseCaseImpl = createImplementation({
     abstraction: UpdateTeam,
     implementation: UpdateTeamUseCase,
-    dependencies: [TeamsRepository, IdentityContext, EventPublisher]
+    dependencies: [TeamsRepository, IdentityContext, EventPublisher, RolesRepository]
 });

--- a/packages/api-core/src/features/security/teams/shared/resolveRoleIdentifiers.ts
+++ b/packages/api-core/src/features/security/teams/shared/resolveRoleIdentifiers.ts
@@ -1,0 +1,60 @@
+import { Result } from "@webiny/feature/api";
+import { RolesRepository } from "../../roles/shared/abstractions.js";
+import { TeamValidationError } from "./errors.js";
+
+/**
+ * Maps whatever a caller used to name a role onto the role IDs a team stores.
+ *
+ * `team.roles` holds IDs and only IDs: GetPermissionsFromIdentity resolves them with `id_in` against
+ * the roles repository. A slug stored here matches nothing, so the team is created, reads correctly
+ * in the admin UI, and grants no permissions at all. Nothing previously caught that, because the
+ * field is typed `string[]` and the use case wrote it through untouched.
+ *
+ * Accepting both forms rather than rejecting slugs: which identifier a given field wants is not
+ * guessable from the outside, and a few lines away in the same area a team is identified by SLUG
+ * (folder permission targets are `team:<slug>`). An identifier that is neither is a genuine mistake
+ * and is reported.
+ */
+export const resolveRoleIdentifiers = async (
+    rolesRepository: RolesRepository.Interface,
+    identifiers: string[]
+): Promise<Result<string[], TeamValidationError>> => {
+    if (identifiers.length === 0) {
+        return Result.ok([]);
+    }
+
+    /*
+     * Every role, in one read. `id_in` and `slug_in` are ANDed by the repository, so they cannot
+     * express "either of these", and a project has few enough roles for the distinction not to
+     * matter. Plugin-defined roles are included, which a filtered query would also have to cover.
+     */
+    const rolesResult = await rolesRepository.list({});
+
+    if (rolesResult.isFail()) {
+        return Result.fail(new TeamValidationError(`Could not load roles: ${rolesResult.error}`));
+    }
+
+    const byId = new Map(rolesResult.value.map(role => [role.id, role.id]));
+    const bySlug = new Map(rolesResult.value.map(role => [role.slug, role.id]));
+
+    const unknown: string[] = [];
+
+    // ID first, so a slug that happens to equal another role's ID cannot shadow it.
+    const roleIds = identifiers.map(identifier => {
+        const resolved = byId.get(identifier) ?? bySlug.get(identifier);
+
+        if (!resolved) {
+            unknown.push(identifier);
+            return identifier;
+        }
+
+        return resolved;
+    });
+
+    if (unknown.length > 0) {
+        const names = unknown.map(identifier => `"${identifier}"`).join(", ");
+        return Result.fail(new TeamValidationError(`Not a known role id or slug: ${names}.`));
+    }
+
+    return Result.ok(roleIds);
+};


### PR DESCRIPTION
`team.roles` holds role IDs and only IDs. `GetPermissionsFromIdentity` resolves them with `id_in`
against the roles repository, so a slug stored there matches nothing: the team is created, reads
correctly in the admin UI, and grants no permissions at all. No error anywhere.

Nothing caught this. The field is typed `string[]` and both use cases wrote it straight through to
`TeamsRepository`. `CreateTeamUseCase`'s dependencies were `[IdentityContext, EventPublisher,
TeamsRepository]`, with no roles repository in sight.

## Why it is so easy to get wrong

Three things line up against you:

- A few lines away in the same feature area, a team is identified by **slug**:
  `GetDefaultPermissionsWithTeams.ts:40` builds `team:${identityTeam.slug}`. So roles go by id,
  teams go by slug, and nothing in the types says which.
- A plugin-defined role gets `id: codeRole.slug` (`RoleProvider.ts:15`). For those, the id and the
  slug are the same string, so passing a slug appears to work. Only a **database** role, whose id is
  an mdbid, actually fails. Anyone testing against the built-in roles sees no problem.
- `RolesRepository.get()` already matches a plugin role "by ID or slug", so tolerance exists
  elsewhere in the same repository.

## The change

`CreateTeam` and `UpdateTeam` resolve either form to the ID the field needs, through one shared
helper in `teams/shared/resolveRoleIdentifiers.ts`.

- IDs are matched first, so a slug that happens to equal another role's id cannot shadow it.
- An identifier that is neither is reported instead of stored.
- `UpdateTeam` resolves only when the update mentions `roles`, so an update that omits them still
  leaves the stored roles alone.

Accepting both rather than rejecting slugs is the point. Rejecting just moves the guessing to the
caller, and the caller has no way to know which identifier this particular field wants.

## Cost

One roles read per create, and per update that changes roles. `id_in` and `slug_in` are ANDed by the
repository, so a single filtered query cannot express "either of these", and a project has few
enough roles that listing them is the simpler option. An empty `roles` array skips the read.

## Testing

Five tests in `packages/api-core/__tests__/security/teams.test.ts`, covering a slug resolving to the
stored id, an id passing through, an unknown identifier being rejected, resolution on update, and an
update that omits roles leaving them alone.

They create a **database** role and assert `role.id !== role.slug` before anything else, because a
plugin role cannot tell the two apart and would pass either way.

`yarn test packages/api-core`: 186 passing across 23 files.

## Context

Found while adding a `createTeam` AI tool in #5589. That tool had to do this resolution itself,
which meant the AI path was the only caller that caught the mistake while the GraphQL mutation and
the admin UI could still create a permissionless team. With this in place the tool drops its own
roles read and goes back to being a thin wrapper over the use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
