### PR TITLE
fix: expect generated `_id` on stored object values

### DIFF
--- a/packages/api-scheduler/src/domain/ScheduledActionMapper.ts
+++ b/packages/api-scheduler/src/domain/ScheduledActionMapper.ts
@@ -8,11 +8,21 @@ export class ScheduledActionMapper {
         action: IScheduledActionEntry<T>
     ): IScheduledAction<T> {
         const { id: scheduleId } = parseIdentifier(action.id);
+        const scheduledBy = action.values.scheduledBy;
         return {
             id: scheduleId,
             targetId: action.values.targetId,
             namespace: action.values.namespace,
-            scheduledBy: action.values.scheduledBy,
+            /**
+             * Mapped field by field on purpose: Headless CMS stores this as an object
+             * field, and object values carry a generated `_id` we don't want to leak
+             * into the identity.
+             */
+            scheduledBy: {
+                id: scheduledBy.id,
+                displayName: scheduledBy.displayName,
+                type: scheduledBy.type
+            },
             scheduledFor: new Date(action.values.scheduledFor),
             actionType: action.values.actionType,
             title: action.values.title,

--- a/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
+++ b/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
@@ -160,7 +160,11 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
                 id: scheduleId,
                 values: {
                     scheduledFor: scheduleFor.toISOString(),
-                    scheduledBy,
+                    /**
+                     * Headless CMS stamps a generated `_id` onto object values in place,
+                     * so it gets a copy and `scheduledBy` stays a clean identity.
+                     */
+                    scheduledBy: { ...scheduledBy },
                     namespace,
                     title,
                     actionType,

--- a/packages/api-workflows/__tests__/WorkflowStateUseCases.test.ts
+++ b/packages/api-workflows/__tests__/WorkflowStateUseCases.test.ts
@@ -35,6 +35,17 @@ const nonOwnerIdentity = {
     type: "user"
 };
 
+/**
+ * Object values written through Headless CMS come back with a generated `_id`, so
+ * identities read off a workflow state step carry one as well.
+ */
+const storedIdentity = (identity: Record<string, string>) => {
+    return {
+        ...identity,
+        _id: expect.any(String)
+    };
+};
+
 describe("Workflow State Use Cases", () => {
     const targetTitle = "App: Some Record Title";
 
@@ -147,6 +158,7 @@ describe("Workflow State Use Cases", () => {
         expect(state.steps).toEqual([
             ...workflow.steps.map(step => {
                 return {
+                    _id: expect.any(String),
                     canReview: false,
                     isOwner: false,
                     canTakeOver: false,
@@ -313,6 +325,7 @@ describe("Workflow State Use Cases", () => {
         expect(stateAfterApprove.state).toEqual(WorkflowStateRecordState.pending);
 
         expect(stateAfterApprove.steps[0]).toEqual({
+            _id: expect.any(String),
             id: "step-1",
             canReview: true,
             canTakeOver: false,
@@ -324,10 +337,11 @@ describe("Workflow State Use Cases", () => {
             teams: state.steps[0].teams,
             state: WorkflowStateRecordState.approved,
             comment: "First step should be approved.",
-            savedBy: reviewerIdentity
+            savedBy: storedIdentity(reviewerIdentity)
         });
 
         expect(stateAfterApprove.steps[1]).toEqual({
+            _id: expect.any(String),
             id: "step-2",
             canReview: true,
             canTakeOver: false,
@@ -373,6 +387,7 @@ describe("Workflow State Use Cases", () => {
         // Verify second step approval
         const stateAfterApproveStep2 = secondApproveResult.value!;
         expect(stateAfterApproveStep2.steps[1]).toEqual({
+            _id: expect.any(String),
             id: "step-2",
             canReview: true,
             canTakeOver: false,
@@ -384,7 +399,7 @@ describe("Workflow State Use Cases", () => {
             notifications: state.steps[1].notifications,
             state: WorkflowStateRecordState.approved,
             comment: "Second step should be approved.",
-            savedBy: reviewerIdentity
+            savedBy: storedIdentity(reviewerIdentity)
         });
 
         // Verify entire workflow is now approved and done
@@ -595,6 +610,7 @@ describe("Workflow State Use Cases", () => {
         // Verify takeover was successful and new reviewer owns the step
         expect(takeOverStateStepResult.steps).toEqual([
             {
+                _id: expect.any(String),
                 canReview: true,
                 canTakeOver: false,
                 color: "blue",
@@ -604,23 +620,22 @@ describe("Workflow State Use Cases", () => {
                 isOwner: true,
                 notifications: [
                     {
+                        _id: expect.any(String),
                         id: "notif-1"
                     }
                 ],
-                savedBy: {
-                    displayName: "Takeover Identity",
-                    id: "takeOver-identity-id",
-                    type: "user"
-                },
+                savedBy: storedIdentity(takeOverIdentity),
                 state: "inReview",
                 teams: [
                     {
+                        _id: expect.any(String),
                         id: "full-access-team"
                     }
                 ],
                 title: "Step 1"
             },
             {
+                _id: expect.any(String),
                 canReview: true,
                 canTakeOver: false,
                 color: "green",
@@ -630,6 +645,7 @@ describe("Workflow State Use Cases", () => {
                 isOwner: false,
                 notifications: [
                     {
+                        _id: expect.any(String),
                         id: "notif-2"
                     }
                 ],
@@ -637,6 +653,7 @@ describe("Workflow State Use Cases", () => {
                 state: "pending",
                 teams: [
                     {
+                        _id: expect.any(String),
                         id: "full-access-team"
                     }
                 ],

--- a/packages/api-workflows/__tests__/WorkflowUseCases.test.ts
+++ b/packages/api-workflows/__tests__/WorkflowUseCases.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { createContextHandler } from "~tests/__helpers/handler.js";
-import type { IWorkflow } from "~/domain/workflow/abstractions.js";
 import { FULL_ACCESS_TEAM_ID } from "@webiny/testing";
 import { GetWorkflowUseCase } from "~/features/workflow/GetWorkflow/index.js";
 import { ListWorkflowsUseCase } from "~/features/workflow/ListWorkflows/index.js";
@@ -53,18 +52,23 @@ describe("Workflows Use Cases", () => {
         expect(workflowResult.isOk()).toBe(true);
         const workflow = workflowResult.value!;
 
-        const expected: IWorkflow = {
+        /**
+         * Object values stored via Headless CMS carry a generated `_id`, so every
+         * step, team and notification is expected to have one.
+         */
+        const expected = {
             id,
             app: "test",
             name: "Test Workflow",
             steps: [
                 {
+                    _id: expect.any(String),
                     id: "step-1",
                     title: "Step 1",
                     description: "This is step 1",
                     color: "blue",
-                    teams: [{ id: FULL_ACCESS_TEAM_ID }],
-                    notifications: [{ id: "notif-1" }]
+                    teams: [{ _id: expect.any(String), id: FULL_ACCESS_TEAM_ID }],
+                    notifications: [{ _id: expect.any(String), id: "notif-1" }]
                 }
             ]
         };

--- a/packages/background-tasks/__tests__/helpers/graphql/logs.ts
+++ b/packages/background-tasks/__tests__/helpers/graphql/logs.ts
@@ -22,6 +22,7 @@ export const createListTaskLogsQuery = () => {
                         executionName
                         iteration
                         items {
+                            _id
                             message
                             createdOn
                             type


### PR DESCRIPTION
## What

Four test jobs have been red on `release/6.5.0` since #5606 added a stable `_id` to object and dynamic-zone values: `api-scheduler-aws`, `background-tasks`, `[DDB] api-workflows` and `[DDB-OS,DDB] api-workflows`.

## Changes

**api-workflows** (tests only). Workflow steps, their teams and notifications, and the identity saved on a state step all carry an `_id` now. Expectations match it with `expect.any(String)`, via a small `storedIdentity()` helper where an identity is compared.

**background-tasks** (tests only). `ensureItemIds` stamps the `_id` onto log items in place, so the object literal the test hands to `updateLog` picks one up and then no longer matched the query result. The `listLogs` query selects `_id`, which also gets the round trip under test.

**api-scheduler** (source). `scheduledBy` is a single object field and an `_id` on an identity means nothing, so instead of teaching three tests about it:

- `ScheduledActionMapper.toAction` maps the identity field by field.
- `ScheduleActionUseCase.schedule` hands the CMS a copy of the identity, so the one it returns is not mutated.

`IScheduledAction.scheduledBy` is typed `Identity` (just `id`, `type`, `displayName`), so the old pass-through made the type lie. Note the `expected` object in `features/useCases.test.ts` is annotated `typeof getResult.value`, which is how this showed up: there was no way to add `_id` to the expectation and keep it type-checking.

## Testing

`yarn test` is green for all three packages locally: api-workflows 53/53, api-scheduler-aws 30/30, background-tasks 88/88. Also re-ran the other api-scheduler consumers (api-scheduler, api-scheduler-server, api-headless-cms-scheduler, api-website-builder-scheduler) since the mapper is shared.

I could not run `yarn test:os packages/api-workflows` here, no OpenSearch available locally. The changed assertions are storage agnostic, so CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)