### PR TITLE
fix(api-websockets-sql): read connection timestamps back as ISO strings

### DIFF
--- a/packages/api-websockets-sql/__tests__/toIsoString.test.ts
+++ b/packages/api-websockets-sql/__tests__/toIsoString.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { toIsoString } from "../src/toIsoString.js";
+
+const ISO = "2026-08-04T17:02:06.028Z";
+
+describe("toIsoString", () => {
+    it("should convert the Date that node-postgres and mysql2 return", () => {
+        expect(toIsoString(new Date(ISO))).toBe(ISO);
+    });
+
+    it("should pass through the ISO string that better-sqlite3 returns", () => {
+        expect(toIsoString(ISO)).toBe(ISO);
+    });
+
+    it("should read a T-less, zone-less timestamp as UTC", () => {
+        expect(toIsoString("2026-08-04 17:02:06")).toBe("2026-08-04T17:02:06.000Z");
+    });
+
+    it("should preserve the instant, whatever shape it arrives in", () => {
+        const date = new Date(ISO);
+
+        expect(new Date(toIsoString(date)).getTime()).toBe(date.getTime());
+        expect(new Date(toIsoString(ISO)).getTime()).toBe(date.getTime());
+    });
+
+    /**
+     * These are the shapes that used to sort below any ISO string and silently drop a user's
+     * connections from the recency filter. Throwing keeps that from happening quietly again.
+     */
+    it.each([
+        ["null", null],
+        ["undefined", undefined],
+        ["a number", 1789041600028],
+        ["an object", {}],
+        ["an unparseable string", "not a date"]
+    ])("should throw rather than stringify %s", (_label, value) => {
+        expect(() => toIsoString(value)).toThrow(/websockets connection timestamp/);
+    });
+});

--- a/packages/api-websockets-sql/src/WebsocketsConnectionRegistry.ts
+++ b/packages/api-websockets-sql/src/WebsocketsConnectionRegistry.ts
@@ -2,6 +2,7 @@ import { WebinyError } from "@webiny/error";
 import { KnexClient } from "@webiny/api-core-sql";
 import { ConnectionRegistry } from "@webiny/api-websockets/exports/api.js";
 import { TableName } from "~/TableName/abstractions.js";
+import { toIsoString } from "~/toIsoString.js";
 
 interface ConnectionRow {
     connectionId: string;
@@ -268,7 +269,7 @@ class WebsocketsConnectionRegistryImpl implements ConnectionRegistry.Interface {
             },
             tenant: row.tenant,
             endpoint: row.endpoint,
-            connectedOn: row.connectedOn
+            connectedOn: toIsoString(row.connectedOn)
         };
     }
 }

--- a/packages/api-websockets-sql/src/toIsoString.ts
+++ b/packages/api-websockets-sql/src/toIsoString.ts
@@ -1,0 +1,36 @@
+import { WebinyError } from "@webiny/error";
+
+/**
+ * Normalize a timestamp read out of a `datetime` column to a UTC ISO string.
+ *
+ * We always write ISO strings, but the column's read shape is the driver's decision: node-postgres
+ * and mysql2 parse it into a `Date`, better-sqlite3 hands back the text it was given, and some
+ * configurations return "2026-08-04 17:02:06" with no `T` and no zone. That wall-clock is UTC,
+ * because that is how it was written, so the space form is read back as UTC.
+ *
+ * Taking `unknown` keeps the variance out of the row type, so the rest of the registry can treat a
+ * timestamp as the `string` it is declared to be. Anything unparseable throws rather than being
+ * stringified: these values are compared against a cutoff to decide which connections are still
+ * live, and a quietly malformed one drops a user's connections with no error to show for it.
+ */
+export const toIsoString = (value: unknown): string => {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (typeof value === "string") {
+        const normalized =
+            value.includes(" ") && !value.includes("T") ? `${value.replace(" ", "T")}Z` : value;
+
+        const parsed = new Date(normalized);
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed.toISOString();
+        }
+    }
+
+    throw new WebinyError(
+        "Could not read a websockets connection timestamp.",
+        "INVALID_CONNECTION_TIMESTAMP",
+        { value }
+    );
+};


### PR DESCRIPTION
## The bug

Server-to-client WebSocket pushes matched **zero** connections on SQL-backed (self-hosted) deployments, so a finished background task never reached the browser. Symptom: file-manager AI image enrichment completes and updates the file, but no "Image enriched" notification appears in Admin. Nothing errors, and the task reports success.

## Cause

`connectedOn` is declared `string` and written as a UTC ISO string, but it lives in a `datetime` column, and the column's read shape is the driver's decision. On Postgres, node-postgres parses it into a `Date`:

```
knex .datetime() on pg => timestamp with time zone
read back is Date     : true
```

`ListConnectionsUseCase` drops stale connections by comparing `connectedOn` against an ISO cutoff string. A `Date` coerces to `"Wed Aug 04 2026 ..."`, which sorts below `"2026-..."`, so every live connection read as expired and was filtered out. `SendToIdentity` then sent to nobody, threw nothing, and the task still reported success.

## Fix

Normalize the value where a row becomes domain data, in the registry's `toData`. The helper takes `unknown`, so the driver's variance stays out of the row type and the rest of the registry can treat a timestamp as the `string` it is declared to be. That also keeps the two registries agreeing: the DynamoDB one stores `connectedOn` as a plain string attribute, and a `Date` written into the document client would be stored as an empty object.

Unparseable values throw rather than being stringified. These values decide which connections are still live, so a quietly malformed one drops a user's connections with nothing to show for it, which is exactly the failure being fixed here. The T-less, zone-less form some drivers return (`"2026-08-04 17:02:06"`) is read as UTC, since that is how it was written.

## Verification

Measured on `next`, all three lanes:

| | before | after |
| --- | --- | --- |
| `yarn test:pglite packages/api-websockets` | 10 failed, 15 passed | **25 passed** |
| `yarn test packages/api-websockets` | passed | **25 passed** |
| `yarn test packages/api-websockets-sql` | 10 passed | **19 passed** |

The pglite lane is the meaningful one, since it is the only lane where a driver returns a `Date`. `websocketsContext.test.ts > should properly list connections` asserts `expect.any(String)` and fails there without this change, which makes it the regression guard.

Nine new unit tests cover the helper: the `Date` that node-postgres and mysql2 return, the ISO string better-sqlite3 returns, the T-less form read as UTC, instant preservation across shapes, and the five inputs that previously would have been stringified into something sorting below every ISO date.

Also verified that the round trip is exact, milliseconds included, and that the column is `timestamp with time zone`, so `toISOString()` yields the correct instant regardless of the server's timezone.

## Scope

Deliberately local to `api-websockets-sql`. It fixes the reported bug without changing how Knex clients are built or how any other package reads a timestamp.

The two other SQL packages with `datetime` columns were checked and neither is affected: `api-core-sql`'s key-value store parses through `new Date(...)`, which absorbs either shape, and `api-audit-logs-sql` writes `.toISOString()` and rebuilds a `Date` in `fromRow`. Within this file, `lastSeen` never passes through `toData`, and `listStale` compares it in SQL.

## Follow-up, not in this PR

`ListConnectionsUseCase` judges recency by `connectedOn` (first connect), while `listStale` correctly uses `lastSeen` (heartbeat). An Admin session open longer than 3 hours, alive and heartbeating with a fresh `lastSeen`, has an old `connectedOn` and gets filtered out, silently losing pushes. Independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)