### PR TITLE
fix(scripts): fix repeated and per-character build output

### DIFF
--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -227,12 +227,29 @@ export const buildPackages = async () => {
 
                     return true;
                 },
-                task: async (ctx, task) => {
+                task: (ctx, task) => {
                     const batchStart = Date.now();
                     let succeeded = 0;
                     let failed = 0;
+                    let settled = 0;
 
                     reporter.batchStart(batchInfo);
+
+                    // Reported from the last package to settle rather than after the subtask
+                    // list has run, because the list has to be returned to Listr (see below)
+                    // and there is no point after that where this task still has control.
+                    const reportBatchEnd = () => {
+                        if (++settled < packages.length) {
+                            return;
+                        }
+
+                        reporter.batchEnd({
+                            ...batchInfo,
+                            succeeded,
+                            failed,
+                            duration: Date.now() - batchStart
+                        });
+                    };
 
                     const subtasks = packages.map(pkg => {
                         return {
@@ -267,6 +284,8 @@ export const buildPackages = async () => {
                                         batch: batchNumber,
                                         duration: Date.now() - packageStart
                                     });
+
+                                    reportBatchEnd();
                                 } catch (err) {
                                     failed++;
                                     failedPackages.add(pkg.packageJson.name);
@@ -277,6 +296,8 @@ export const buildPackages = async () => {
                                         error: (err as Error).message
                                     });
 
+                                    reportBatchEnd();
+
                                     ctx.skip = true;
                                     throw new PackageBuildError(pkg, err as Error);
                                 }
@@ -284,26 +305,19 @@ export const buildPackages = async () => {
                         };
                     });
 
-                    const subtaskList = task.newListr(subtasks, {
+                    // The list has to be returned, not run here. Listr only takes a subtask
+                    // list over when it is returned from a task: it then swaps the nested
+                    // list onto the silent renderer and hands its tasks to the renderer that
+                    // is already drawing. Calling `.run()` on it instead leaves it with a
+                    // renderer of its own, and the two draw over each other — neither can
+                    // erase the other's frame, so every redraw appends another copy of the
+                    // package list.
+                    return task.newListr(subtasks, {
                         concurrent: buildInParallel,
                         exitOnError: false,
                         collectErrors: true,
                         rendererOptions: { showErrorMessage: false }
                     });
-
-                    // Run the subtasks here rather than returning the list, so the batch's
-                    // own totals are known by the time `batchEnd` is reported. `exitOnError`
-                    // is off, so this never throws — errors surface on `tasks.errors`.
-                    try {
-                        await subtaskList.run();
-                    } finally {
-                        reporter.batchEnd({
-                            ...batchInfo,
-                            succeeded,
-                            failed,
-                            duration: Date.now() - batchStart
-                        });
-                    }
                 }
             };
         }),

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -22,6 +22,14 @@ const argv = yargs(hideBin(process.argv)).parse();
 
 const projectFolder = path.basename(process.cwd());
 
+// Listr wraps every task title to `process.stdout.columns`, and only falls back to 80 columns
+// when that is nullish. A pty that reports no size (0 columns, e.g. when the build runs inside
+// an embedded terminal) therefore gets a negative width, and each title is hard-wrapped to one
+// character per line. Give it a usable width instead.
+if (process.stdout.isTTY && !process.stdout.columns) {
+    process.stdout.columns = 80;
+}
+
 const sendNotification = (title: string, message: string) => {
     try {
         notifier.notify({ title, message });

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -235,20 +235,29 @@ export const buildPackages = async () => {
 
                     reporter.batchStart(batchInfo);
 
-                    // Reported from the last package to settle rather than after the subtask
-                    // list has run, because the list has to be returned to Listr (see below)
-                    // and there is no point after that where this task still has control.
                     const reportBatchEnd = () => {
-                        if (++settled < packages.length) {
-                            return;
-                        }
-
                         reporter.batchEnd({
                             ...batchInfo,
                             succeeded,
                             failed,
                             duration: Date.now() - batchStart
                         });
+                    };
+
+                    // Nothing will settle, so the batch has to close itself out. Every
+                    // `batch:start` is paired with a `batch:end` in the JSON event stream.
+                    if (!packages.length) {
+                        reportBatchEnd();
+                        return;
+                    }
+
+                    // Reported by the last package to settle rather than after the subtask list
+                    // has run, because the list has to be returned to Listr (see below) and
+                    // there is no point after that where this task still has control.
+                    const reportBatchEndOnLastSettled = () => {
+                        if (++settled === packages.length) {
+                            reportBatchEnd();
+                        }
                     };
 
                     const subtasks = packages.map(pkg => {
@@ -284,8 +293,6 @@ export const buildPackages = async () => {
                                         batch: batchNumber,
                                         duration: Date.now() - packageStart
                                     });
-
-                                    reportBatchEnd();
                                 } catch (err) {
                                     failed++;
                                     failedPackages.add(pkg.packageJson.name);
@@ -296,10 +303,10 @@ export const buildPackages = async () => {
                                         error: (err as Error).message
                                     });
 
-                                    reportBatchEnd();
-
                                     ctx.skip = true;
                                     throw new PackageBuildError(pkg, err as Error);
+                                } finally {
+                                    reportBatchEndOnLastSettled();
                                 }
                             }
                         };
@@ -309,7 +316,7 @@ export const buildPackages = async () => {
                     // list over when it is returned from a task: it then swaps the nested
                     // list onto the silent renderer and hands its tasks to the renderer that
                     // is already drawing. Calling `.run()` on it instead leaves it with a
-                    // renderer of its own, and the two draw over each other — neither can
+                    // renderer of its own, and the two then draw over each other. Neither can
                     // erase the other's frame, so every redraw appends another copy of the
                     // package list.
                     return task.newListr(subtasks, {

--- a/scripts/typecheckTests/index.ts
+++ b/scripts/typecheckTests/index.ts
@@ -11,6 +11,12 @@ import { writeReport, REPORT_DIR } from "./writeReport.js";
 
 const { green, red, yellow } = chalk;
 
+// Same guard as in `scripts/buildPackages`: Listr hard-wraps task titles one character per line
+// when the pty reports 0 columns, because its own fallback only covers a nullish width.
+if (process.stdout.isTTY && !process.stdout.columns) {
+    process.stdout.columns = 80;
+}
+
 const argv = yargs(hideBin(process.argv))
     .option("p", {
         alias: "package",


### PR DESCRIPTION
## What

Two defects in the `yarn build` progress output, both in `scripts/buildPackages`.

### 1. The package list repeats on every redraw

This is the one that fills the terminal with the same batch of package names over and over. It is a regression from #5629 (`b4321927bc`, merged 2026-09-02), so every multi-package build since then has done it.

Before that PR, each batch task ended by returning its subtask list:

```ts
return task.newListr(subtasks, { ... });
```

#5629 added the JSON reporter, which needed the batch totals at `batchEnd`, and returning the list leaves the task no point after the subtasks finish. So the list was run by hand instead:

```ts
const subtaskList = task.newListr(subtasks, { ... });
try {
    await subtaskList.run();
} finally {
    reporter.batchEnd({ ...batchInfo, succeeded, failed, duration: Date.now() - batchStart });
}
```

Listr only adopts a subtask list when the task *returns* it. `Task.run` does this to the returned value (`node_modules/listr2/dist/index.mjs:1927`):

```js
if (result instanceof Listr) {
    result.rendererClass = getRendererClass("silent");
    this.subtasks = result.tasks;
    this.emit("SUBTASK", this.subtasks);
    result = result.run(context);
}
```

Run the list yourself and none of that happens. `Listr.run` unconditionally does `this.renderer = new this.rendererClass(...)`, so the nested list keeps a full renderer of its own, and two renderers write to the same stdout with independent `log-update` state. Neither can erase the other's frame, so each redraw appends another copy of the package list.

Two things kept it hidden for nine days. `--json` mode sets `silentRendererCondition`, so the path #5629 was written to exercise never draws at all. And in text mode the double-draw only shows once a batch is big enough to fill past the screen, so a two or three package build looks fine.

The fix returns the list again and reports `batchEnd` from the last package to settle, which is the last moment the batch task still has the counts to hand. A batch with no packages has nothing to settle, so it closes itself out directly, keeping every `batch:start` paired with a `batch:end` in the event stream.

### 2. Titles hard-wrapped one character per line

Separate, older, and not what was reported. Listr wraps every task title to `process.stdout.columns` and only falls back to 80 when the value is nullish (`index.mjs:933`). A pty reporting no size gives it a `0`, which passes the `??` and comes out negative. `wrap-ansi` runs with `hard: true`, so at a width of 1 or less it breaks `@webiny/error` into 13 lines. Fixed by setting a width of 80 when the stream is a TTY that reports none, here and in `scripts/typecheckTests/index.ts`.

Piped output is untouched. There `columns` is genuinely `undefined` and Listr's own fallback applies.

## Verified

`yarn build -p @webiny/error -p @webiny/validation -p @webiny/plugins -p @webiny/utils --no-cache`, in a 40 row by 120 column pty, measuring what is left on screen after the renderer's last erase:

| | lines left un-erased | `@webiny/error` among them |
|---|---|---|
| before | 105 | 27 times |
| after | 4 (the summary) | once |

Every frame is now preceded by an erase that matches the frame it is clearing.

Also checked with a package edited to fail compilation, since the reporting moved:

- `--json`: `batch:start` then `batch:end` with succeeded 1 / failed 1, then `build:end` with `success: false`, `built: 1`, `failed: 1`.
- text: still prints `Error building 1 package(s)`, the package's error, and `Build failed`.
- A clean `--json` run still pairs `batch:start` with `batch:end` and reports succeeded 2 / failed 0.

## Not included

`packages/create-webiny-project/src/features/CreateWebinyProject.ts` uses Listr too, but returns its subtask lists and so is not affected by either problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)