### PR TITLE
build: warn when the repo has no CodeGraph index

### DIFF
--- a/.codegraph-test/.gitignore
+++ b/.codegraph-test/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -17,6 +17,7 @@ import { queueMetaWrite } from "./writeMetaQueue";
 import { createReporter } from "./reporter";
 import { previewBuild } from "./previewBuild";
 import { getPackagesWhitelist } from "./getPackagesWhitelist";
+import { warnIfNoCodeGraph } from "./warnIfNoCodeGraph";
 
 const argv = yargs(hideBin(process.argv)).parse();
 
@@ -61,6 +62,8 @@ export const buildPackages = async () => {
     const options = argv as BuildOptions;
 
     const reporter = createReporter(options.json === true);
+
+    warnIfNoCodeGraph();
 
     if (options.preview === true) {
         // Nothing below this point runs: a preview reports the plan and stops. Notably,

--- a/scripts/buildPackages/src/warnIfNoCodeGraph.ts
+++ b/scripts/buildPackages/src/warnIfNoCodeGraph.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+import chalk from "chalk";
+
+const { yellow, green } = chalk;
+
+/**
+ * CodeGraph indexes the repo so that coding agents can look up symbols, callers and call
+ * paths instead of grepping their way through it. A build doesn't need it, but working
+ * without it is slower and less accurate, so point it out when the index isn't there.
+ *
+ * Written to stderr, because in `--json` mode stdout carries the event stream.
+ */
+export const warnIfNoCodeGraph = () => {
+    // Nobody is running agents on the CI machine, so the warning is just noise there.
+    if (process.env.CI) {
+        return;
+    }
+
+    if (fs.existsSync(path.join(process.cwd(), ".codegraph"))) {
+        return;
+    }
+
+    console.warn(
+        yellow("⚠ No .codegraph folder found.") +
+            ` Coding agents use CodeGraph to find their way around this repo. Run ${green(
+                "npx codegraph init"
+            )} to index it.\n`
+    );
+};


### PR DESCRIPTION
## What

`yarn build` now checks for a `.codegraph` folder in the project root. If it isn't there, the build prints one line before it starts:

```
⚠ No .codegraph folder found. Coding agents use CodeGraph to find their way around this repo. Run npx codegraph init to index it.
```

The build itself is unaffected, this is only a nudge.

## Why

We lean on CodeGraph so agents working in this repo can look up symbols, callers and call paths instead of grepping through 200-odd packages. An unindexed checkout still works, it just makes every agent slower and less accurate, and there is nothing today that tells you the index is missing.

## Details

- The warning goes to stderr, so `--json` keeps a clean event stream on stdout and `--preview` output stays parseable with a plain `JSON.parse`.
- Skipped when `CI` is set. Nobody is running agents on the build machine, so it would be pure noise there.
- Checked in `buildPackages.ts` right after the reporter is created, which covers normal builds and previews alike.

## Testing

Ran `yarn build --preview` with the index present (no extra output) and called the check with a cwd that has no `.codegraph` (warning prints), plus with `CI` set (silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)