### PR TITLE
feat(ai-powerups): resolve AI models per capability instead of taking the first provider

### DIFF
--- a/packages/ai-powerups/__tests__/features/AiImageEnrichment/AiImageEnrichmentStreamRoute.test.ts
+++ b/packages/ai-powerups/__tests__/features/AiImageEnrichment/AiImageEnrichmentStreamRoute.test.ts
@@ -24,6 +24,7 @@ const prepared: IPreparedImageEnrichment = {
     imageBase64: "aGVsbG8=",
     imageMediaType: "image/png",
     model: "anthropic/claude-sonnet-4-5",
+    prompt: "Describe this image.",
     connection: { sdkName: "anthropic", apiKey: "key" }
 };
 

--- a/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
@@ -1,39 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Container } from "@webiny/di";
 import CapabilitiesHandler from "~/api/features/Capabilities/CapabilitiesHandler.js";
-import { AiCapability } from "~/api/features/Capabilities/abstractions.js";
 import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
-
-const OUR_PROMPT = "Webiny's own comparison prompt.";
-
-/** Mirrors the real capability: fixed prompt, so the replace switch is offered. */
-class ComparisonCapability implements AiCapability.Interface {
-    readonly id = "cms.compareEntryRevisions";
-    readonly label = "CMS revision comparison";
-    readonly description = "For tests.";
-    readonly defaultRole = "fast" as const;
-    readonly guidance = OUR_PROMPT;
-}
-
-/** Prompt assembled per request, so no replaceable guidance. */
-class EntryCapability implements AiCapability.Interface {
-    readonly id = "cms.generateEntry";
-    readonly label = "CMS entry generation";
-    readonly description = "For tests.";
-    readonly defaultRole = "standard" as const;
-}
 
 function buildHandler(): AiPowerUpsSettingsGroupHandler.Interface {
     const container = new Container();
-    container.register(
-        AiCapability.createImplementation({
-            implementation: ComparisonCapability,
-            dependencies: []
-        })
-    );
-    container.register(
-        AiCapability.createImplementation({ implementation: EntryCapability, dependencies: [] })
-    );
     container.register(CapabilitiesHandler);
 
     return container.resolve(AiPowerUpsSettingsGroupHandler);
@@ -56,9 +27,7 @@ describe("CapabilitiesHandler", () => {
                     roleId: null,
                     connectionId: null,
                     model: null,
-                    additionalInstructions: null,
-                    replacePrompt: null,
-                    guidance: null
+                    additionalInstructions: null
                 }
             }
         });
@@ -73,9 +42,7 @@ describe("CapabilitiesHandler", () => {
                     roleId: "fast",
                     connectionId: "conn-1",
                     model: "anthropic/claude-haiku-4-5",
-                    additionalInstructions: "Be brief.",
-                    replacePrompt: true,
-                    guidance: "Custom."
+                    additionalInstructions: "Be brief."
                 }
             }
         });
@@ -117,8 +84,7 @@ describe("CapabilitiesHandler", () => {
                         roleId: null,
                         connectionId: "",
                         model: null,
-                        additionalInstructions: "Keep it short.",
-                        replacePrompt: null
+                        additionalInstructions: "Keep it short."
                     }
                 }
             },
@@ -131,85 +97,19 @@ describe("CapabilitiesHandler", () => {
     });
 
     /*
-     * The admin pre-fills the prompt textarea with our own text so flipping the switch shows you
-     * what you are about to edit. That default comes back on every save, and persisting it would
-     * freeze the prompt: flip the switch a year later and you get whatever shipped the day the row
-     * was written, which is the trap append-by-default exists to avoid.
+     * There is no prompt field here any more. Replacing a capability's prompt was offered and then
+     * removed: for most capabilities the prompt carries the output contract the surrounding code
+     * parses, so it is implementation rather than settings. `additionalInstructions` is the whole
+     * of prompt customisation now.
      */
-    it("discards a prompt that is a verbatim copy of ours", async () => {
-        const stored = await handler.mapToStorage(
-            { overrides: { "cms.compareEntryRevisions": { guidance: OUR_PROMPT } } },
-            null
-        );
-
-        expect((stored as any).overrides).toEqual({});
-    });
-
-    it("discards our prompt even when the switch is on, since it tracks ours anyway", async () => {
-        const stored = await handler.mapToStorage(
-            {
-                overrides: {
-                    "cms.compareEntryRevisions": { replacePrompt: true, guidance: OUR_PROMPT }
-                }
-            },
-            null
-        );
-
-        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
-            replacePrompt: true
+    it("rejects a prompt override, which is no longer a thing", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: { "cms.compareEntryRevisions": { guidance: "Mine now." } }
         });
-    });
 
-    /*
-     * The test is content, not the switch. Keying off the switch looked equivalent and was not: it
-     * threw away a prompt somebody had actually written the moment they toggled the switch off and
-     * saved, so toggling was lossy.
-     */
-    it("keeps a prompt the project wrote, even with the switch off", async () => {
-        const stored = await handler.mapToStorage(
-            {
-                overrides: {
-                    "cms.compareEntryRevisions": {
-                        replacePrompt: false,
-                        guidance: "Our own house prompt."
-                    }
-                }
-            },
-            null
-        );
-
-        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
-            guidance: "Our own house prompt."
-        });
-    });
-
-    it("keeps a prompt for a capability that declares none of its own", async () => {
-        const stored = await handler.mapToStorage(
-            { overrides: { "cms.generateEntry": { guidance: "Something." } } },
-            null
-        );
-
-        expect((stored as any).overrides["cms.generateEntry"]).toEqual({
-            guidance: "Something."
-        });
-    });
-
-    it("keeps the rest of a row when only the echoed prompt is discarded", async () => {
-        const stored = await handler.mapToStorage(
-            {
-                overrides: {
-                    "cms.compareEntryRevisions": {
-                        additionalInstructions: "Never translate product names.",
-                        guidance: OUR_PROMPT
-                    }
-                }
-            },
-            null
-        );
-
-        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
-            additionalInstructions: "Never translate product names."
-        });
+        // Zod strips the unknown key rather than failing, so the check is that it never lands.
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ overrides: { "cms.compareEntryRevisions": {} } });
     });
 
     it("round-trips an absent section to an empty override map", () => {

--- a/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
@@ -99,6 +99,66 @@ describe("CapabilitiesHandler", () => {
         });
     });
 
+    /*
+     * The admin pre-fills the prompt textarea with our own text so flipping the switch shows you
+     * what you are about to edit. That default came back on every save regardless of the switch,
+     * so a project that never touched capabilities ended up storing verbatim copies of three of
+     * our prompts. A stored copy is a frozen copy, which is the trap append-by-default exists to
+     * avoid.
+     */
+    it("discards a prompt when the replace switch is off", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "cms.compareEntryRevisions": {
+                        replacePrompt: false,
+                        guidance: "Webiny's own prompt, echoed back by the form."
+                    }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides).toEqual({});
+    });
+
+    it("keeps a prompt the project has explicitly taken over", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "cms.compareEntryRevisions": {
+                        replacePrompt: true,
+                        guidance: "Our own house prompt."
+                    }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
+            replacePrompt: true,
+            guidance: "Our own house prompt."
+        });
+    });
+
+    it("keeps the rest of a row when only the prompt is discarded", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "wb.translatePage": {
+                        additionalInstructions: "Never translate product names.",
+                        guidance: "Echoed default."
+                    }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides["wb.translatePage"]).toEqual({
+            additionalInstructions: "Never translate product names."
+        });
+    });
+
     it("round-trips an absent section to an empty override map", () => {
         expect(handler.mapFromStorage(undefined)).toEqual({ overrides: {} });
     });

--- a/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import CapabilitiesHandler from "~/api/features/Capabilities/CapabilitiesHandler.js";
+import type { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+
+/**
+ * The handler takes no dependencies, so instantiating the registered implementation directly is
+ * enough and avoids standing up a container for a pure mapper.
+ */
+const handler = new (CapabilitiesHandler as unknown as {
+    new (): AiPowerUpsSettingsGroupHandler.Interface;
+})();
+
+describe("CapabilitiesHandler", () => {
+    /*
+     * The admin form sends `null` for a field nobody has touched, and every field in an override is
+     * untouched by default. The first version of this schema required strings, so saving the
+     * settings screen without configuring a single capability failed with four copies of
+     * "Invalid input: expected string, received null" and no indication of which section was at
+     * fault.
+     */
+    it("accepts the nulls the form sends for untouched fields", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: {
+                "cms.generateEntry": {
+                    roleId: null,
+                    connectionId: null,
+                    model: null,
+                    additionalInstructions: null,
+                    replacePrompt: null,
+                    guidance: null
+                }
+            }
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts a fully configured override", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: {
+                "cms.generateEntry": {
+                    roleId: "fast",
+                    connectionId: "conn-1",
+                    model: "anthropic/claude-haiku-4-5",
+                    additionalInstructions: "Be brief.",
+                    replacePrompt: true,
+                    guidance: "Custom."
+                }
+            }
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("still rejects a role that does not exist", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: { "cms.generateEntry": { roleId: "cheapest" } }
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    it("drops an override where every field is empty", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "cms.generateEntry": {
+                        roleId: null,
+                        connectionId: null,
+                        additionalInstructions: "   "
+                    },
+                    "wb.generatePage": { additionalInstructions: "Keep it short." }
+                }
+            },
+            null
+        );
+
+        expect(Object.keys((stored as any).overrides)).toEqual(["wb.generatePage"]);
+    });
+
+    it("keeps nulls and empty strings out of a stored override", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "wb.generatePage": {
+                        roleId: null,
+                        connectionId: "",
+                        model: null,
+                        additionalInstructions: "Keep it short.",
+                        replacePrompt: null
+                    }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides["wb.generatePage"]).toEqual({
+            additionalInstructions: "Keep it short."
+        });
+    });
+
+    it("round-trips an absent section to an empty override map", () => {
+        expect(handler.mapFromStorage(undefined)).toEqual({ overrides: {} });
+    });
+});

--- a/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
@@ -1,14 +1,45 @@
 import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
 import CapabilitiesHandler from "~/api/features/Capabilities/CapabilitiesHandler.js";
-import type { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { AiCapability } from "~/api/features/Capabilities/abstractions.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
 
-/**
- * The handler takes no dependencies, so instantiating the registered implementation directly is
- * enough and avoids standing up a container for a pure mapper.
- */
-const handler = new (CapabilitiesHandler as unknown as {
-    new (): AiPowerUpsSettingsGroupHandler.Interface;
-})();
+const OUR_PROMPT = "Webiny's own comparison prompt.";
+
+/** Mirrors the real capability: fixed prompt, so the replace switch is offered. */
+class ComparisonCapability implements AiCapability.Interface {
+    readonly id = "cms.compareEntryRevisions";
+    readonly label = "CMS revision comparison";
+    readonly description = "For tests.";
+    readonly defaultRole = "fast" as const;
+    readonly guidance = OUR_PROMPT;
+}
+
+/** Prompt assembled per request, so no replaceable guidance. */
+class EntryCapability implements AiCapability.Interface {
+    readonly id = "cms.generateEntry";
+    readonly label = "CMS entry generation";
+    readonly description = "For tests.";
+    readonly defaultRole = "standard" as const;
+}
+
+function buildHandler(): AiPowerUpsSettingsGroupHandler.Interface {
+    const container = new Container();
+    container.register(
+        AiCapability.createImplementation({
+            implementation: ComparisonCapability,
+            dependencies: []
+        })
+    );
+    container.register(
+        AiCapability.createImplementation({ implementation: EntryCapability, dependencies: [] })
+    );
+    container.register(CapabilitiesHandler);
+
+    return container.resolve(AiPowerUpsSettingsGroupHandler);
+}
+
+const handler = buildHandler();
 
 describe("CapabilitiesHandler", () => {
     /*
@@ -101,33 +132,45 @@ describe("CapabilitiesHandler", () => {
 
     /*
      * The admin pre-fills the prompt textarea with our own text so flipping the switch shows you
-     * what you are about to edit. That default came back on every save regardless of the switch,
-     * so a project that never touched capabilities ended up storing verbatim copies of three of
-     * our prompts. A stored copy is a frozen copy, which is the trap append-by-default exists to
-     * avoid.
+     * what you are about to edit. That default comes back on every save, and persisting it would
+     * freeze the prompt: flip the switch a year later and you get whatever shipped the day the row
+     * was written, which is the trap append-by-default exists to avoid.
      */
-    it("discards a prompt when the replace switch is off", async () => {
+    it("discards a prompt that is a verbatim copy of ours", async () => {
         const stored = await handler.mapToStorage(
-            {
-                overrides: {
-                    "cms.compareEntryRevisions": {
-                        replacePrompt: false,
-                        guidance: "Webiny's own prompt, echoed back by the form."
-                    }
-                }
-            },
+            { overrides: { "cms.compareEntryRevisions": { guidance: OUR_PROMPT } } },
             null
         );
 
         expect((stored as any).overrides).toEqual({});
     });
 
-    it("keeps a prompt the project has explicitly taken over", async () => {
+    it("discards our prompt even when the switch is on, since it tracks ours anyway", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "cms.compareEntryRevisions": { replacePrompt: true, guidance: OUR_PROMPT }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
+            replacePrompt: true
+        });
+    });
+
+    /*
+     * The test is content, not the switch. Keying off the switch looked equivalent and was not: it
+     * threw away a prompt somebody had actually written the moment they toggled the switch off and
+     * saved, so toggling was lossy.
+     */
+    it("keeps a prompt the project wrote, even with the switch off", async () => {
         const stored = await handler.mapToStorage(
             {
                 overrides: {
                     "cms.compareEntryRevisions": {
-                        replacePrompt: true,
+                        replacePrompt: false,
                         guidance: "Our own house prompt."
                     }
                 }
@@ -136,25 +179,35 @@ describe("CapabilitiesHandler", () => {
         );
 
         expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
-            replacePrompt: true,
             guidance: "Our own house prompt."
         });
     });
 
-    it("keeps the rest of a row when only the prompt is discarded", async () => {
+    it("keeps a prompt for a capability that declares none of its own", async () => {
+        const stored = await handler.mapToStorage(
+            { overrides: { "cms.generateEntry": { guidance: "Something." } } },
+            null
+        );
+
+        expect((stored as any).overrides["cms.generateEntry"]).toEqual({
+            guidance: "Something."
+        });
+    });
+
+    it("keeps the rest of a row when only the echoed prompt is discarded", async () => {
         const stored = await handler.mapToStorage(
             {
                 overrides: {
-                    "wb.translatePage": {
+                    "cms.compareEntryRevisions": {
                         additionalInstructions: "Never translate product names.",
-                        guidance: "Echoed default."
+                        guidance: OUR_PROMPT
                     }
                 }
             },
             null
         );
 
-        expect((stored as any).overrides["wb.translatePage"]).toEqual({
+        expect((stored as any).overrides["cms.compareEntryRevisions"]).toEqual({
             additionalInstructions: "Never translate product names."
         });
     });

--- a/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { Result } from "@webiny/feature/api";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import { AiCapability } from "~/api/features/Capabilities/abstractions.js";
+import { ResolveAiCapabilityUseCase } from "~/api/features/Capabilities/abstractions.js";
+import { ResolveAiCapabilityUseCaseImplementation } from "~/api/features/Capabilities/ResolveAiCapabilityUseCase.js";
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+type Overrides = IAiPowerUpsSettings["capabilities"]["overrides"];
+type Roles = IAiPowerUpsSettings["modelRoles"]["roles"];
+
+const CHEAP = "anthropic/claude-haiku-4-5";
+const MAIN = "anthropic/claude-sonnet-4-5";
+
+const roles = (partial: Partial<Roles> = {}): Roles => ({
+    fast: { connectionId: "", model: "" },
+    standard: { connectionId: "conn-1", model: MAIN },
+    vision: { connectionId: "", model: "" },
+    ...partial
+});
+
+function settings(params: {
+    roles?: Partial<Roles>;
+    overrides?: Overrides;
+    connections?: IAiPowerUpsSettings["connections"]["presets"];
+}): IAiPowerUpsSettings {
+    return {
+        connections: {
+            presets: params.connections ?? [
+                {
+                    id: "conn-1",
+                    name: "Anthropic (prod)",
+                    sdkName: "anthropic",
+                    apiKeyMasked: "sk-ant-1…9999",
+                    apiKeyEncrypted: "encrypted-1"
+                }
+            ]
+        },
+        modelRoles: { roles: roles(params.roles) },
+        capabilities: { overrides: params.overrides ?? {} }
+    } as unknown as IAiPowerUpsSettings;
+}
+
+/** `standard` and `fast` differ, so which role answered is visible in the model alone. */
+class TestCapability implements AiCapability.Interface {
+    readonly id = "test.capability";
+    readonly label = "Test capability";
+    readonly description = "For tests.";
+    readonly defaultRole = "standard" as const;
+    readonly guidance = "Webiny guidance.";
+}
+
+class RolelessCapability implements AiCapability.Interface {
+    readonly id = "test.noGuidance";
+    readonly label = "No guidance";
+    readonly description = "Prompt is assembled per request.";
+    readonly defaultRole = "vision" as const;
+}
+
+class StubEncryption implements Encryption.Interface {
+    async encrypt(plain: string) {
+        return `encrypted-${plain}`;
+    }
+    /** Prefixed so a test can tell a decrypted key from the stored ciphertext. */
+    async decrypt(encrypted: string) {
+        return `decrypted:${encrypted}`;
+    }
+}
+
+function resolver(value: IAiPowerUpsSettings) {
+    const container = new Container();
+
+    container.register(
+        AiCapability.createImplementation({ implementation: TestCapability, dependencies: [] })
+    );
+    container.register(
+        AiCapability.createImplementation({ implementation: RolelessCapability, dependencies: [] })
+    );
+    // Closes over `value`, so it has to be built per call rather than hoisted like the others.
+    class StubGetSettings implements GetSettingsUseCase.Interface {
+        async execute() {
+            return Result.ok(value);
+        }
+    }
+
+    container.register(
+        GetSettingsUseCase.createImplementation({
+            implementation: StubGetSettings,
+            dependencies: []
+        })
+    );
+    container.register(
+        Encryption.createImplementation({
+            implementation: StubEncryption,
+            dependencies: []
+        })
+    );
+    container.register(ResolveAiCapabilityUseCaseImplementation);
+
+    return container.resolve(ResolveAiCapabilityUseCase);
+}
+
+describe("ResolveAiCapabilityUseCase", () => {
+    it("uses the capability's default role", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.isOk()).toBe(true);
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+        expect(result.value.connection).toEqual({
+            sdkName: "anthropic",
+            apiKey: "decrypted:encrypted-1"
+        });
+    });
+
+    it("decrypts the key rather than handing back what is stored", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.value.connection.apiKey).not.toBe("encrypted-1");
+    });
+
+    it("honours a role chosen for the capability", async () => {
+        const result = await resolver(
+            settings({
+                roles: { fast: { connectionId: "conn-1", model: CHEAP } },
+                overrides: { "test.capability": { roleId: "fast" } }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(CHEAP);
+        expect(result.value.roleId).toBe("fast");
+    });
+
+    it("lets a pinned connection and model beat the role", async () => {
+        const result = await resolver(
+            settings({
+                overrides: {
+                    "test.capability": { roleId: "fast", connectionId: "conn-1", model: CHEAP }
+                }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(CHEAP);
+        expect(result.value.roleId).toBeNull();
+    });
+
+    it("ignores a half-finished pin, because guessing the other half is worse", async () => {
+        const result = await resolver(
+            settings({ overrides: { "test.capability": { model: CHEAP } } })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+    });
+
+    it("falls back to standard when the requested role is empty, and says so", async () => {
+        // Reproduces an upgrade: migration fills only `standard`, so image work keeps running on
+        // the model it ran on before rather than failing.
+        const result = await resolver(settings({})).execute("test.noGuidance");
+
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+        expect(result.value.fellBackToStandard).toBe(true);
+    });
+
+    it("fails with a message naming the settings screen when nothing is configured", async () => {
+        const result = await resolver(
+            settings({ roles: { standard: { connectionId: "", model: "" } } })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("Model roles");
+    });
+
+    it("fails when the role names a connection that has been deleted", async () => {
+        const result = await resolver(settings({ connections: [] })).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("no longer exists");
+    });
+
+    it("fails when the connection exists but has no key", async () => {
+        const result = await resolver(
+            settings({
+                connections: [
+                    {
+                        id: "conn-1",
+                        name: "Anthropic (prod)",
+                        sdkName: "anthropic",
+                        apiKeyMasked: "",
+                        apiKeyEncrypted: ""
+                    }
+                ]
+            })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("no API key");
+    });
+
+    it("rejects a model paired with another vendor's credential", async () => {
+        const result = await resolver(
+            settings({ roles: { standard: { connectionId: "conn-1", model: "openai/gpt-5" } } })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("cannot run on");
+    });
+
+    it("returns the capability's own guidance by default", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.value.guidance).toBe("Webiny guidance.");
+        expect(result.value.additionalInstructions).toBe("");
+    });
+
+    it("keeps our guidance while the replace switch is off, even with text saved", async () => {
+        const result = await resolver(
+            settings({
+                overrides: {
+                    "test.capability": { guidance: "Their prompt.", replacePrompt: false }
+                }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.guidance).toBe("Webiny guidance.");
+    });
+
+    it("uses their guidance once the replace switch is on", async () => {
+        const result = await resolver(
+            settings({
+                overrides: {
+                    "test.capability": { guidance: "Their prompt.", replacePrompt: true }
+                }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.guidance).toBe("Their prompt.");
+    });
+
+    it("passes additional instructions through, trimmed", async () => {
+        const result = await resolver(
+            settings({
+                overrides: { "test.capability": { additionalInstructions: "  Be brief.  " } }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.additionalInstructions).toBe("Be brief.");
+    });
+
+    it("fails loudly on an unregistered capability id", async () => {
+        const result = await resolver(settings({})).execute("nope.notRegistered");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("Unknown AI capability");
+    });
+});

--- a/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
@@ -216,28 +216,16 @@ describe("ResolveAiCapabilityUseCase", () => {
         expect(result.value.additionalInstructions).toBe("");
     });
 
-    it("keeps our guidance while the replace switch is off, even with text saved", async () => {
+    it("ignores a prompt override, because there is no such thing any more", async () => {
         const result = await resolver(
             settings({
                 overrides: {
-                    "test.capability": { guidance: "Their prompt.", replacePrompt: false }
+                    "test.capability": { guidance: "Mine now." } as Overrides[string]
                 }
             })
         ).execute("test.capability");
 
         expect(result.value.guidance).toBe("Webiny guidance.");
-    });
-
-    it("uses their guidance once the replace switch is on", async () => {
-        const result = await resolver(
-            settings({
-                overrides: {
-                    "test.capability": { guidance: "Their prompt.", replacePrompt: true }
-                }
-            })
-        ).execute("test.capability");
-
-        expect(result.value.guidance).toBe("Their prompt.");
     });
 
     it("passes additional instructions through, trimmed", async () => {

--- a/packages/ai-powerups/__tests__/features/Connections/ConnectionsHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Connections/ConnectionsHandler.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { Masker } from "@webiny/api-core/features/masker/index.js";
+import ConnectionsHandler from "~/api/features/Connections/ConnectionsHandler.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import type { ConnectionsSettings } from "~/api/features/Connections/types.js";
+
+class StubEncryption implements Encryption.Interface {
+    async encrypt(plain: string) {
+        return `enc(${plain})`;
+    }
+    async decrypt(encrypted: string) {
+        return encrypted.replace(/^enc\((.*)\)$/, "$1");
+    }
+}
+
+class StubMasker implements Masker.Interface {
+    mask(value: string) {
+        return `${value.slice(0, 4)}…${value.slice(-2)}`;
+    }
+}
+
+function handler(): AiPowerUpsSettingsGroupHandler.Interface {
+    const container = new Container();
+    container.register(
+        Encryption.createImplementation({ implementation: StubEncryption, dependencies: [] })
+    );
+    container.register(
+        Masker.createImplementation({ implementation: StubMasker, dependencies: [] })
+    );
+    container.register(ConnectionsHandler);
+
+    return container.resolve(AiPowerUpsSettingsGroupHandler);
+}
+
+/** A settings blob from before this section existed. */
+const legacyRaw = {
+    providers: {
+        presets: [
+            {
+                id: "prov-1",
+                name: "Anthropic",
+                model: "anthropic/claude-sonnet-4-5",
+                apiKeyEncrypted: "enc(sk-ant-real)",
+                apiKeyMasked: "sk-a…al"
+            }
+        ]
+    }
+};
+
+describe("ConnectionsHandler", () => {
+    it("derives connections from the legacy providers section", () => {
+        const result = handler().mapFromStorage(undefined, legacyRaw) as ConnectionsSettings;
+
+        expect(result.presets).toEqual([
+            {
+                id: "prov-1",
+                name: "Anthropic",
+                sdkName: "anthropic",
+                apiKeyMasked: "sk-a…al",
+                apiKeyEncrypted: "enc(sk-ant-real)"
+            }
+        ]);
+    });
+
+    it("ignores the legacy section once connections exist", () => {
+        const result = handler().mapFromStorage(
+            { presets: [{ id: "c1", name: "Mine", sdkName: "openai", apiKeyEncrypted: "enc(k)" }] },
+            legacyRaw
+        ) as ConnectionsSettings;
+
+        expect(result.presets).toHaveLength(1);
+        expect(result.presets[0].id).toBe("c1");
+    });
+
+    /*
+     * The bug this test exists for. The form only ever sees a mask, so an unchanged key comes back
+     * as the mask and `mapToStorage` has to recognise it and carry the ciphertext forward. On the
+     * first save after an upgrade the "existing" value is itself derived from `providers`, and
+     * `UpdateSettingsRepository` was calling `mapFromStorage` without the full blob. It compared
+     * against an empty list, matched nothing, and wrote an empty key: the project's real API key,
+     * silently gone on the first save.
+     */
+    it("carries a masked key forward instead of blanking it", async () => {
+        const h = handler();
+        const existing = h.mapFromStorage(undefined, legacyRaw);
+
+        const stored = (await h.mapToStorage(
+            {
+                presets: [
+                    { id: "prov-1", name: "Anthropic", sdkName: "anthropic", apiKey: "sk-a…al" }
+                ]
+            },
+            existing
+        )) as { presets: Array<{ apiKeyEncrypted: string }> };
+
+        expect(stored.presets[0].apiKeyEncrypted).toBe("enc(sk-ant-real)");
+    });
+
+    it("encrypts and masks a newly entered key", async () => {
+        const stored = (await handler().mapToStorage(
+            {
+                presets: [{ id: "c1", name: "New", sdkName: "openai", apiKey: "sk-brand-new-key" }]
+            },
+            null
+        )) as { presets: Array<{ apiKeyEncrypted: string; apiKeyMasked: string }> };
+
+        expect(stored.presets[0].apiKeyEncrypted).toBe("enc(sk-brand-new-key)");
+        expect(stored.presets[0].apiKeyMasked).not.toContain("brand");
+    });
+
+    it("accepts a null apiKey from the form", () => {
+        const result = handler().inputSchema.safeParse({
+            presets: [{ id: "c1", name: "New", sdkName: "openai", apiKey: null }]
+        });
+
+        expect(result.success).toBe(true);
+    });
+});

--- a/packages/ai-powerups/src/admin/features/feature.ts
+++ b/packages/ai-powerups/src/admin/features/feature.ts
@@ -1,5 +1,6 @@
 import { createFeature } from "@webiny/feature/admin";
 import { ListModelsFeature } from "~/admin/features/listModels/index.js";
+import { ListCapabilitiesFeature } from "~/admin/features/listCapabilities/index.js";
 import { SharedSettingsFeature } from "~/admin/features/settings/shared/index.js";
 import { GetSettingsFeature } from "~/admin/features/settings/getSettings/index.js";
 import { UpdateSettingsFeature } from "~/admin/features/settings/updateSettings/index.js";
@@ -13,6 +14,7 @@ export const AiPowerUpsHeadlessFeatures = createFeature({
         GetSettingsFeature.register(container);
         UpdateSettingsFeature.register(container);
         ListModelsFeature.register(container);
+        ListCapabilitiesFeature.register(container);
         GeneratePageContentFeature.register(container);
         CompareEntryRevisionsFeature.register(container);
     },

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
@@ -10,7 +10,6 @@ const LIST_CAPABILITIES = /* GraphQL */ `
                 label
                 description
                 defaultRole
-                guidance
             }
         }
     }

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
@@ -1,0 +1,40 @@
+import { MainGraphQLClient } from "@webiny/app/exports/admin.js";
+import { ListCapabilitiesGateway as GatewayAbstraction } from "./abstractions.js";
+import type { AiCapability } from "./abstractions.js";
+
+const LIST_CAPABILITIES = /* GraphQL */ `
+    query ListAiCapabilities {
+        aiPowerUps {
+            listCapabilities {
+                id
+                label
+                description
+                defaultRole
+                guidance
+            }
+        }
+    }
+`;
+
+type ListCapabilitiesResponse = {
+    aiPowerUps: {
+        listCapabilities: AiCapability[];
+    };
+};
+
+class ListCapabilitiesGatewayImpl implements GatewayAbstraction.Interface {
+    constructor(private client: MainGraphQLClient.Interface) {}
+
+    async execute(): Promise<AiCapability[]> {
+        const response = await this.client.execute<ListCapabilitiesResponse>({
+            query: LIST_CAPABILITIES
+        });
+
+        return response.aiPowerUps.listCapabilities ?? [];
+    }
+}
+
+export const ListCapabilitiesGateway = GatewayAbstraction.createImplementation({
+    implementation: ListCapabilitiesGatewayImpl,
+    dependencies: [MainGraphQLClient]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesRepository.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesRepository.ts
@@ -1,0 +1,30 @@
+import { makeAutoObservable, runInAction } from "mobx";
+import {
+    ListCapabilitiesRepository as RepoAbstraction,
+    ListCapabilitiesGateway
+} from "./abstractions.js";
+import type { AiCapability } from "./abstractions.js";
+
+class ListCapabilitiesRepositoryImpl implements RepoAbstraction.Interface {
+    private capabilities: AiCapability[] = [];
+
+    constructor(private gateway: ListCapabilitiesGateway.Interface) {
+        makeAutoObservable(this);
+    }
+
+    async execute(): Promise<void> {
+        const capabilities = await this.gateway.execute();
+        runInAction(() => {
+            this.capabilities = capabilities;
+        });
+    }
+
+    getCapabilities(): AiCapability[] {
+        return this.capabilities;
+    }
+}
+
+export const ListCapabilitiesRepository = RepoAbstraction.createImplementation({
+    implementation: ListCapabilitiesRepositoryImpl,
+    dependencies: [ListCapabilitiesGateway]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesUseCase.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesUseCase.ts
@@ -1,0 +1,17 @@
+import {
+    ListCapabilitiesUseCase as UseCaseAbstraction,
+    ListCapabilitiesRepository
+} from "./abstractions.js";
+
+class ListCapabilitiesUseCaseImpl implements UseCaseAbstraction.Interface {
+    constructor(private repository: ListCapabilitiesRepository.Interface) {}
+
+    async execute(): Promise<void> {
+        return this.repository.execute();
+    }
+}
+
+export const ListCapabilitiesUseCase = UseCaseAbstraction.createImplementation({
+    implementation: ListCapabilitiesUseCaseImpl,
+    dependencies: [ListCapabilitiesRepository]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
@@ -5,8 +5,6 @@ export interface AiCapability {
     label: string;
     description: string;
     defaultRole: string;
-    /** Null when the capability's prompt is assembled per request and cannot be replaced. */
-    guidance: string | null;
 }
 
 export interface IListCapabilitiesGateway {

--- a/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
@@ -1,0 +1,44 @@
+import { createAbstraction } from "@webiny/feature/admin";
+
+export interface AiCapability {
+    id: string;
+    label: string;
+    description: string;
+    defaultRole: string;
+    /** Null when the capability's prompt is assembled per request and cannot be replaced. */
+    guidance: string | null;
+}
+
+export interface IListCapabilitiesGateway {
+    execute(): Promise<AiCapability[]>;
+}
+
+export const ListCapabilitiesGateway = createAbstraction<IListCapabilitiesGateway>(
+    "AiPowerUps/ListCapabilitiesGateway"
+);
+export namespace ListCapabilitiesGateway {
+    export type Interface = IListCapabilitiesGateway;
+}
+
+export interface IListCapabilitiesRepository {
+    execute(): Promise<void>;
+    getCapabilities(): AiCapability[];
+}
+
+export const ListCapabilitiesRepository = createAbstraction<IListCapabilitiesRepository>(
+    "AiPowerUps/ListCapabilitiesRepository"
+);
+export namespace ListCapabilitiesRepository {
+    export type Interface = IListCapabilitiesRepository;
+}
+
+export interface IListCapabilitiesUseCase {
+    execute(): Promise<void>;
+}
+
+export const ListCapabilitiesUseCase = createAbstraction<IListCapabilitiesUseCase>(
+    "AiPowerUps/ListCapabilitiesUseCase"
+);
+export namespace ListCapabilitiesUseCase {
+    export type Interface = IListCapabilitiesUseCase;
+}

--- a/packages/ai-powerups/src/admin/features/listCapabilities/feature.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/feature.ts
@@ -1,0 +1,19 @@
+import { createFeature } from "@webiny/feature/admin";
+import { ListCapabilitiesUseCase as UseCaseAbstraction } from "./abstractions.js";
+import { ListCapabilitiesUseCase } from "./ListCapabilitiesUseCase.js";
+import { ListCapabilitiesRepository } from "./ListCapabilitiesRepository.js";
+import { ListCapabilitiesGateway } from "./ListCapabilitiesGateway.js";
+
+export const ListCapabilitiesFeature = createFeature({
+    name: "AiPowerUps/ListCapabilities",
+    register(container) {
+        container.register(ListCapabilitiesUseCase);
+        container.register(ListCapabilitiesRepository).inSingletonScope();
+        container.register(ListCapabilitiesGateway).inSingletonScope();
+    },
+    resolve(container) {
+        return {
+            useCase: container.resolve(UseCaseAbstraction)
+        };
+    }
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/index.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/index.ts
@@ -1,0 +1,7 @@
+export { ListCapabilitiesFeature } from "./feature.js";
+export {
+    ListCapabilitiesUseCase,
+    ListCapabilitiesRepository,
+    ListCapabilitiesGateway
+} from "./abstractions.js";
+export type { AiCapability } from "./abstractions.js";

--- a/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
@@ -19,14 +19,29 @@ export interface IAiPowerUpsPersonaPreset {
     style?: string;
 }
 
+export interface IAiPowerUpsCapabilityOverride {
+    roleId?: string;
+    connectionId?: string;
+    model?: string;
+    additionalInstructions?: string;
+    replacePrompt?: boolean;
+    guidance?: string;
+}
+
 export interface IAiPowerUpsSettings {
-    providers: {
+    connections: {
         presets: {
+            id: string;
             name: string;
-            description: string;
-            model: string;
+            sdkName: string;
             apiKey: string;
         }[];
+    };
+    modelRoles: {
+        roles: Record<string, { connectionId: string; model: string }>;
+    };
+    capabilities: {
+        overrides: Record<string, IAiPowerUpsCapabilityOverride>;
     };
     readerPersonas: {
         presets: IAiPowerUpsPersonaPreset[];

--- a/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
@@ -24,8 +24,6 @@ export interface IAiPowerUpsCapabilityOverride {
     connectionId?: string;
     model?: string;
     additionalInstructions?: string;
-    replacePrompt?: boolean;
-    guidance?: string;
 }
 
 export interface IAiPowerUpsSettings {

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
@@ -49,7 +49,13 @@ class AiPowerUpsSettingsPresenterImpl implements PresenterAbstraction.Interface 
         this.errors = [];
 
         try {
-            const data = await this.getSettings.execute();
+            // Groups that build fields from server data get to load it first. Both run in
+            // parallel; neither depends on the other.
+            const [data] = await Promise.all([
+                this.getSettings.execute(),
+                Promise.all(this.groups.map(group => group.init?.()))
+            ]);
+
             runInAction(() => {
                 this.form = this.buildForm();
                 this.form.setData(data);

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
@@ -49,14 +49,34 @@ class AiPowerUpsSettingsPresenterImpl implements PresenterAbstraction.Interface 
         this.errors = [];
 
         try {
-            // Groups that build fields from server data get to load it first. Both run in
-            // parallel; neither depends on the other.
-            const [data] = await Promise.all([
+            /*
+             * Groups that build fields from server data get to load it first, in parallel with the
+             * settings themselves.
+             *
+             * `allSettled`, not `all`: a group whose init fails must not take the screen down with
+             * it. One broken query used to leave the page with a heading, a Save button and no tabs
+             * at all, which hid the working sections and the personas someone came here to edit.
+             * Now the failure is reported and every other tab still renders.
+             */
+            const [data, initResults] = await Promise.all([
                 this.getSettings.execute(),
-                Promise.all(this.groups.map(group => group.init?.()))
+                Promise.allSettled(this.groups.map(group => group.init?.()))
             ]);
 
+            const initErrors = initResults.flatMap((result, index) => {
+                if (result.status !== "rejected") {
+                    return [];
+                }
+
+                const label = this.groups[index].label;
+                const reason =
+                    result.reason instanceof Error ? result.reason.message : String(result.reason);
+
+                return [`Could not load the "${label}" section: ${reason}`];
+            });
+
             runInAction(() => {
+                this.errors = initErrors;
                 this.form = this.buildForm();
                 this.form.setData(data);
             });

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/feature.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/feature.ts
@@ -1,7 +1,9 @@
 import { createFeature } from "@webiny/feature/admin";
 import { AiPowerUpsSettingsPresenter as PresenterAbstraction } from "./abstractions.js";
 import { AiPowerUpsSettingsPresenter } from "./AiPowerUpsSettingsPresenter.js";
-import { ProviderSettings } from "../ProvidersSettings.js";
+import { ConnectionsSettings } from "../ConnectionsSettings.js";
+import { ModelRolesSettings } from "../ModelRolesSettings.js";
+import { CapabilitiesSettings } from "../CapabilitiesSettings.js";
 import { ReaderPersonasSettings } from "../ReaderPersonasSettings.js";
 import { WriterPersonasSettings } from "../WriterPersonasSettings.js";
 import { ProjectsSettings } from "../ProjectsSettings.js";
@@ -9,7 +11,16 @@ import { ProjectsSettings } from "../ProjectsSettings.js";
 export const AiPowerUpsSettingsFeature = createFeature({
     name: "AiPowerUps/Settings/Presenter",
     register(container) {
-        container.register(ProviderSettings);
+        /*
+         * Registration order is tab order. Configuration first (a key, then what each role runs,
+         * then per-feature exceptions), then the prompt content: personas and projects.
+         *
+         * `ProvidersSettings` is gone from the UI. Its stored section still round-trips on the api
+         * so `Connections` and `ModelRoles` can seed themselves from it once.
+         */
+        container.register(ConnectionsSettings);
+        container.register(ModelRolesSettings);
+        container.register(CapabilitiesSettings);
         container.register(ReaderPersonasSettings);
         container.register(WriterPersonasSettings);
         container.register(ProjectsSettings);

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/hasUsableModel.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/hasUsableModel.ts
@@ -1,0 +1,24 @@
+import type { IAiPowerUpsSettings } from "~/admin/features/settings/shared/abstractions.js";
+
+/**
+ * Whether a feature that runs on the Standard role has something to run on.
+ *
+ * The AI entry points hide themselves when the project has no model configured, and they used to
+ * test `providers.presets.length > 0` for it. That test passed for a row with no key in it, so the
+ * button appeared and the request failed. This one checks the whole chain the api will walk: the
+ * role is filled, the connection it names still exists, and that connection has a key.
+ *
+ * Admin only ever sees the masked key, and the mask is non-empty exactly when a key is stored, so
+ * it answers the question without the plaintext leaving the api.
+ */
+export const hasUsableModel = (settings: IAiPowerUpsSettings | null): boolean => {
+    const standard = settings?.modelRoles?.roles?.["standard"];
+
+    if (!standard?.model || !standard.connectionId) {
+        return false;
+    }
+
+    const connection = settings?.connections?.presets?.find(c => c.id === standard.connectionId);
+
+    return Boolean(connection?.apiKey);
+};

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/index.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/index.ts
@@ -1,3 +1,4 @@
 export { AiPowerUpsSettingsFeature } from "./feature.js";
 export { useAiPowerUpsSettings } from "./useAiPowerUpsSettings.js";
+export { hasUsableModel } from "./hasUsableModel.js";
 export { AiPowerUpsSettingsGroup } from "./settingsGroup.js";

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/settingsGroup.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/settingsGroup.ts
@@ -15,6 +15,15 @@ export interface IAiPowerUpsSettingsGroup {
     label: string;
     description?: string;
     icon?: Icon;
+    /**
+     * Awaited before `buildForm` runs.
+     *
+     * Field *options* are evaluated lazily on render, so a group that only needs server data for a
+     * select can fetch it in the background. Field *structure* is not: the Capabilities group
+     * builds one field per capability registered on the api, so that list has to be in hand before
+     * the form is built or the tab comes up empty.
+     */
+    init?(): Promise<void>;
     buildForm(formBuilder: IAiPowerUpsSettingsGroupFormBuilder): void;
 }
 

--- a/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
@@ -1,0 +1,216 @@
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListCapabilitiesUseCase,
+    ListCapabilitiesRepository
+} from "~/admin/features/listCapabilities/abstractions.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+import { AI_MODEL_ROLE_DISPLAY, roleLabel } from "./modelRoles.js";
+import type { AiCapability } from "~/admin/features/listCapabilities/abstractions.js";
+import type { FormModel, FormModelFactory } from "@webiny/app-admin";
+
+interface ConnectionRow {
+    id: string;
+    name: string;
+    sdkName: string;
+}
+
+/**
+ * One row per AI feature, all of them empty by default.
+ *
+ * The rows come from the api's registered capabilities, so a feature that declares one appears here
+ * without a change to this file. That is the point: the previous plan was a hand-maintained tab per
+ * feature, which is the kind of list that stops matching reality on the second addition.
+ */
+class CapabilitiesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "capabilities";
+    label = "Capabilities";
+    description = "Per-feature model and prompt overrides. Empty means inherit.";
+
+    constructor(
+        private listCapabilities: ListCapabilitiesUseCase.Interface,
+        private capabilitiesRepository: ListCapabilitiesRepository.Interface,
+        private listModels: ListModelsUseCase.Interface,
+        private modelsRepository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await Promise.all([this.listCapabilities.execute(), this.listModels.execute()]);
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            overrides: fields
+                .object()
+                .label("Capabilities")
+                .renderer("passthrough")
+                .fields(f =>
+                    Object.fromEntries(
+                        this.capabilitiesRepository
+                            .getCapabilities()
+                            .map(capability => [
+                                capability.id,
+                                this.buildCapabilityField(f, capability)
+                            ])
+                    )
+                )
+        }));
+
+        form.layout(layout => [layout.row("overrides")]);
+    }
+
+    private buildCapabilityField(
+        f: FormModelFactory.FieldBuilderRegistry,
+        capability: AiCapability
+    ): FormModelFactory.FieldBuilder {
+        const inheritLabel = `Inherit (${roleLabel(capability.defaultRole)})`;
+
+        return f
+            .object()
+            .label(capability.label)
+            .renderer("objectAccordionSingle", {
+                itemTitle: capability.label,
+                itemDescription: capability.description,
+                // Closed by default. Every row is empty until someone changes something, so an
+                // expanded list of five would be five screens of nothing.
+                open: false
+            })
+            .fields(cf => ({
+                roleId: cf
+                    .text()
+                    .label("Model role")
+                    .description("Which role supplies this feature's model.")
+                    .options(() => [
+                        { label: inheritLabel, value: "" },
+                        ...AI_MODEL_ROLE_DISPLAY.map(role => ({
+                            label: role.label,
+                            value: role.id
+                        }))
+                    ]),
+
+                /*
+                 * Pinning a model bypasses roles for this one feature. It is the escape hatch, not
+                 * the mechanism: a project that pins everything has thrown away the indirection
+                 * that makes "switch our cheap model" a single edit.
+                 */
+                connectionId: cf
+                    .text()
+                    .label("Pin a connection")
+                    .description("Advanced. Overrides the role above for this feature only.")
+                    .options(({ form }) => [
+                        { label: "Use the role's connection", value: "" },
+                        ...this.getConnections(form).map(c => ({ label: c.name, value: c.id }))
+                    ]),
+                model: cf
+                    .text()
+                    .label("Pin a model")
+                    .disabledWhen(({ form }) => !this.getPinnedConnection(form, capability.id))
+                    .description(
+                        "Both the connection and the model must be set for a pin to apply."
+                    )
+                    .options(({ form }) => this.getModelOptions(form, capability.id)),
+
+                additionalInstructions: cf
+                    .text()
+                    .label("Additional instructions")
+                    .renderer("textarea", { rows: 5 })
+                    .description(
+                        "Appended to this feature's prompt. Use this for house style and standing rules."
+                    )
+                    .note(
+                        "Appending is the safe option: you keep receiving prompt improvements from Webiny."
+                    ),
+
+                /*
+                 * A full replacement is offered only where the prompt is fixed text. Where the code
+                 * assembles it per request (from a content model schema, say), letting someone
+                 * replace it is just a way to break generation, so the field is not rendered.
+                 */
+                ...(capability.guidance
+                    ? {
+                          replacePrompt: cf
+                              .boolean()
+                              .label("Replace the prompt entirely")
+                              .renderer("switch")
+                              .description(
+                                  "Advanced. Your text replaces Webiny's prompt for this feature."
+                              )
+                              .note(
+                                  "Once you replace it, improvements Webiny makes to this prompt no longer reach you. You own it from then on."
+                              ),
+                          guidance: cf
+                              .text()
+                              .label("Prompt")
+                              .renderer("textarea", { rows: 14 })
+                              .hiddenWhen(({ form }) => !this.isReplacing(form, capability.id))
+                              .defaultValue(capability.guidance)
+                              .description(
+                                  "The full prompt sent for this feature. Additional instructions are still appended below it."
+                              )
+                      }
+                    : {})
+            }));
+    }
+
+    private getConnections(form: FormModel.Interface): ConnectionRow[] {
+        const data = form.getData() as { connections?: { presets?: ConnectionRow[] } };
+        return (data.connections?.presets ?? []).filter(c => c.id && c.name);
+    }
+
+    private getOverride(
+        form: FormModel.Interface,
+        capabilityId: string
+    ): { connectionId?: string; replacePrompt?: boolean } {
+        const data = form.getData() as {
+            capabilities?: {
+                overrides?: Record<string, { connectionId?: string; replacePrompt?: boolean }>;
+            };
+        };
+        return data.capabilities?.overrides?.[capabilityId] ?? {};
+    }
+
+    private isReplacing(form: FormModel.Interface, capabilityId: string): boolean {
+        return this.getOverride(form, capabilityId).replacePrompt === true;
+    }
+
+    private getPinnedConnection(
+        form: FormModel.Interface,
+        capabilityId: string
+    ): ConnectionRow | undefined {
+        const connectionId = this.getOverride(form, capabilityId).connectionId;
+
+        if (!connectionId) {
+            return undefined;
+        }
+
+        return this.getConnections(form).find(c => c.id === connectionId);
+    }
+
+    private getModelOptions(form: FormModel.Interface, capabilityId: string) {
+        const connection = this.getPinnedConnection(form, capabilityId);
+
+        if (!connection) {
+            return [];
+        }
+
+        return this.modelsRepository
+            .getModels()
+            .filter(model => model.providerId === connection.sdkName)
+            .map(model => ({
+                label: model.modelName,
+                value: `${model.providerId}/${model.modelId}`
+            }));
+    }
+}
+
+export const CapabilitiesSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: CapabilitiesSettingsImpl,
+    dependencies: [
+        ListCapabilitiesUseCase,
+        ListCapabilitiesRepository,
+        ListModelsUseCase,
+        ListModelsRepository
+    ]
+});

--- a/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
@@ -133,37 +133,8 @@ class CapabilitiesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
                             "Appended to this feature's prompt. Use this for house style and standing rules."
                         )
                         .note(
-                            "Appending is the safe option: you keep receiving prompt improvements from Webiny."
-                        ),
-
-                    /*
-                     * A full replacement is offered only where the prompt is fixed text. Where the code
-                     * assembles it per request (from a content model schema, say), letting someone
-                     * replace it is just a way to break generation, so the field is not rendered.
-                     */
-                    ...(capability.guidance
-                        ? {
-                              replacePrompt: cf
-                                  .boolean()
-                                  .label("Replace the prompt entirely")
-                                  .renderer("switch")
-                                  .description(
-                                      "Advanced. Your text replaces Webiny's prompt for this feature."
-                                  )
-                                  .note(
-                                      "Once you replace it, improvements Webiny makes to this prompt no longer reach you. You own it from then on."
-                                  ),
-                              guidance: cf
-                                  .text()
-                                  .label("Prompt")
-                                  .renderer("textarea", { rows: 14 })
-                                  .hiddenWhen(({ form }) => !this.isReplacing(form, capability.id))
-                                  .defaultValue(capability.guidance)
-                                  .description(
-                                      "The full prompt sent for this feature. Additional instructions are still appended below it."
-                                  )
-                          }
-                        : {})
+                            "Appending keeps Webiny's prompt in place, including the output format the feature depends on."
+                        )
                 }))
         );
     }
@@ -176,17 +147,11 @@ class CapabilitiesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
     private getOverride(
         form: FormModel.Interface,
         capabilityId: string
-    ): { connectionId?: string; replacePrompt?: boolean } {
+    ): { connectionId?: string } {
         const data = form.getData() as {
-            capabilities?: {
-                overrides?: Record<string, { connectionId?: string; replacePrompt?: boolean }>;
-            };
+            capabilities?: { overrides?: Record<string, { connectionId?: string }> };
         };
         return data.capabilities?.overrides?.[capabilityId] ?? {};
-    }
-
-    private isReplacing(form: FormModel.Interface, capabilityId: string): boolean {
-        return this.getOverride(form, capabilityId).replacePrompt === true;
     }
 
     private getPinnedConnection(

--- a/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
@@ -65,93 +65,107 @@ class CapabilitiesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
         f: FormModelFactory.FieldBuilderRegistry,
         capability: AiCapability
     ): FormModelFactory.FieldBuilder {
-        const inheritLabel = `Inherit (${roleLabel(capability.defaultRole)})`;
+        const defaultRoleLabel = roleLabel(capability.defaultRole);
 
-        return f
-            .object()
-            .label(capability.label)
-            .renderer("objectAccordionSingle", {
-                itemTitle: capability.label,
-                itemDescription: capability.description,
-                // Closed by default. Every row is empty until someone changes something, so an
-                // expanded list of five would be five screens of nothing.
-                open: false
-            })
-            .fields(cf => ({
-                roleId: cf
-                    .text()
-                    .label("Model role")
-                    .description("Which role supplies this feature's model.")
-                    .options(() => [
-                        { label: inheritLabel, value: "" },
-                        ...AI_MODEL_ROLE_DISPLAY.map(role => ({
-                            label: role.label,
-                            value: role.id
-                        }))
-                    ]),
-
+        return (
+            f
+                .object()
+                .label(capability.label)
                 /*
-                 * Pinning a model bypasses roles for this one feature. It is the escape hatch, not
-                 * the mechanism: a project that pins everything has thrown away the indirection
-                 * that makes "switch our cheap model" a single edit.
+                 * Callbacks, not strings: a string is read as a field name, not as literal text. The
+                 * title happened to survive that because the renderer falls back to the field label,
+                 * but the description silently vanished.
                  */
-                connectionId: cf
-                    .text()
-                    .label("Pin a connection")
-                    .description("Advanced. Overrides the role above for this feature only.")
-                    .options(({ form }) => [
-                        { label: "Use the role's connection", value: "" },
-                        ...this.getConnections(form).map(c => ({ label: c.name, value: c.id }))
-                    ]),
-                model: cf
-                    .text()
-                    .label("Pin a model")
-                    .disabledWhen(({ form }) => !this.getPinnedConnection(form, capability.id))
-                    .description(
-                        "Both the connection and the model must be set for a pin to apply."
-                    )
-                    .options(({ form }) => this.getModelOptions(form, capability.id)),
+                .renderer("objectAccordionSingle", {
+                    itemTitle: () => capability.label,
+                    itemDescription: () => capability.description,
+                    // Closed by default. Every row is empty until someone changes something, so an
+                    // expanded list of five would be five screens of nothing.
+                    open: false
+                })
+                .fields(cf => ({
+                    /*
+                     * The inherited role goes in the description, not in the option list. An option
+                     * with an empty value is dropped by the select renderer, so the "Inherit (Fast)"
+                     * entry never rendered and nothing said which role this feature falls back to.
+                     * Clearing the field is done with the select's own reset control.
+                     */
+                    roleId: cf
+                        .text()
+                        .label("Model role")
+                        .description(
+                            `Which role supplies this feature's model. Left empty, it uses ${defaultRoleLabel}.`
+                        )
+                        .options(() =>
+                            AI_MODEL_ROLE_DISPLAY.map(role => ({
+                                label: role.label,
+                                value: role.id
+                            }))
+                        ),
 
-                additionalInstructions: cf
-                    .text()
-                    .label("Additional instructions")
-                    .renderer("textarea", { rows: 5 })
-                    .description(
-                        "Appended to this feature's prompt. Use this for house style and standing rules."
-                    )
-                    .note(
-                        "Appending is the safe option: you keep receiving prompt improvements from Webiny."
-                    ),
+                    /*
+                     * Pinning a model bypasses roles for this one feature. It is the escape hatch, not
+                     * the mechanism: a project that pins everything has thrown away the indirection
+                     * that makes "switch our cheap model" a single edit.
+                     */
+                    connectionId: cf
+                        .text()
+                        .label("Pin a connection")
+                        .description("Advanced. Overrides the role above for this feature only.")
+                        .options(({ form }) => [
+                            { label: "Use the role's connection", value: "" },
+                            ...this.getConnections(form).map(c => ({ label: c.name, value: c.id }))
+                        ]),
+                    model: cf
+                        .text()
+                        .label("Pin a model")
+                        .disabledWhen(({ form }) => !this.getPinnedConnection(form, capability.id))
+                        .description(
+                            "Both the connection and the model must be set for a pin to apply."
+                        )
+                        .options(({ form }) => this.getModelOptions(form, capability.id)),
 
-                /*
-                 * A full replacement is offered only where the prompt is fixed text. Where the code
-                 * assembles it per request (from a content model schema, say), letting someone
-                 * replace it is just a way to break generation, so the field is not rendered.
-                 */
-                ...(capability.guidance
-                    ? {
-                          replacePrompt: cf
-                              .boolean()
-                              .label("Replace the prompt entirely")
-                              .renderer("switch")
-                              .description(
-                                  "Advanced. Your text replaces Webiny's prompt for this feature."
-                              )
-                              .note(
-                                  "Once you replace it, improvements Webiny makes to this prompt no longer reach you. You own it from then on."
-                              ),
-                          guidance: cf
-                              .text()
-                              .label("Prompt")
-                              .renderer("textarea", { rows: 14 })
-                              .hiddenWhen(({ form }) => !this.isReplacing(form, capability.id))
-                              .defaultValue(capability.guidance)
-                              .description(
-                                  "The full prompt sent for this feature. Additional instructions are still appended below it."
-                              )
-                      }
-                    : {})
-            }));
+                    additionalInstructions: cf
+                        .text()
+                        .label("Additional instructions")
+                        .renderer("textarea", { rows: 5 })
+                        .description(
+                            "Appended to this feature's prompt. Use this for house style and standing rules."
+                        )
+                        .note(
+                            "Appending is the safe option: you keep receiving prompt improvements from Webiny."
+                        ),
+
+                    /*
+                     * A full replacement is offered only where the prompt is fixed text. Where the code
+                     * assembles it per request (from a content model schema, say), letting someone
+                     * replace it is just a way to break generation, so the field is not rendered.
+                     */
+                    ...(capability.guidance
+                        ? {
+                              replacePrompt: cf
+                                  .boolean()
+                                  .label("Replace the prompt entirely")
+                                  .renderer("switch")
+                                  .description(
+                                      "Advanced. Your text replaces Webiny's prompt for this feature."
+                                  )
+                                  .note(
+                                      "Once you replace it, improvements Webiny makes to this prompt no longer reach you. You own it from then on."
+                                  ),
+                              guidance: cf
+                                  .text()
+                                  .label("Prompt")
+                                  .renderer("textarea", { rows: 14 })
+                                  .hiddenWhen(({ form }) => !this.isReplacing(form, capability.id))
+                                  .defaultValue(capability.guidance)
+                                  .description(
+                                      "The full prompt sent for this feature. Additional instructions are still appended below it."
+                                  )
+                          }
+                        : {})
+                }))
+        );
     }
 
     private getConnections(form: FormModel.Interface): ConnectionRow[] {

--- a/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/CmsGenerateContentButton.tsx
+++ b/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/CmsGenerateContentButton.tsx
@@ -5,7 +5,10 @@ import { ReactComponent as ChatIcon } from "@webiny/icons/auto_fix_high.svg";
 import { useOpenDialog } from "@webiny/app-admin";
 import { useModel } from "@webiny/app-headless-cms/admin/components/ModelProvider/useModel.js";
 import { CMS_GENERATE_CONTENT_DIALOG } from "./CmsGenerateContentDialog.js";
-import { useAiPowerUpsSettings } from "~/admin/presentation/AiPowerUpsSettings/index.js";
+import {
+    hasUsableModel,
+    useAiPowerUpsSettings
+} from "~/admin/presentation/AiPowerUpsSettings/index.js";
 import { useContentEntryFormPresenter } from "@webiny/app-headless-cms/exports/admin/cms/entry/editor.js";
 
 export const CmsGenerateContentButton = observer(() => {
@@ -18,7 +21,7 @@ export const CmsGenerateContentButton = observer(() => {
         return null;
     }
 
-    if (!settings || settings.providers.presets.length === 0) {
+    if (!hasUsableModel(settings)) {
         return null;
     }
 

--- a/packages/ai-powerups/src/admin/presentation/ConnectionsSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/ConnectionsSettings.ts
@@ -1,0 +1,87 @@
+import { generateAlphaNumericId } from "@webiny/utils";
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+
+/**
+ * One row per API key. The model select moved to Model roles, so adding a second Anthropic model no
+ * longer means pasting the same key twice.
+ */
+class ConnectionsSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "connections";
+    label = "Connections";
+    description = "API keys for the AI vendors this project uses.";
+
+    constructor(
+        private useCase: ListModelsUseCase.Interface,
+        private repository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await this.useCase.execute();
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            presets: fields
+                .object()
+                .label("Connections")
+                .renderer("objectAccordionMultiple", {
+                    container: false,
+                    addItemLabel: "Add connection",
+                    itemTitle: (data, index) => String(data.name || `Connection #${index + 1}`)
+                })
+                .fields(f => ({
+                    id: f
+                        .text()
+                        .hidden()
+                        .defaultValue(() => generateAlphaNumericId(10)),
+                    name: f
+                        .text()
+                        .label("Name")
+                        .required("Name is required")
+                        .description(
+                            "How this connection appears when picking a model. Name it after the key, not the vendor, so two keys for the same vendor stay distinguishable."
+                        ),
+                    sdkName: f
+                        .text()
+                        .label("Vendor")
+                        .required("Vendor is required")
+                        .description("Which provider this key belongs to.")
+                        .options(() => this.getVendorOptions())
+                        .renderer("select"),
+                    apiKey: f
+                        .text()
+                        .label("API Key")
+                        .required("API Key is required")
+                        .description(
+                            "Encrypted at rest. Only the last few characters are shown after saving."
+                        )
+                }))
+                .list()
+        }));
+
+        form.layout(layout => [layout.row("presets")]);
+    }
+
+    /**
+     * Derived from the registered SDK factories rather than hardcoded, so a project that registers
+     * its own `AiSdkFactory` shows up here without a change to this file.
+     */
+    private getVendorOptions() {
+        const seen = new Map<string, string>();
+
+        for (const model of this.repository.getModels()) {
+            seen.set(model.providerId, model.providerName);
+        }
+
+        return [...seen.entries()].map(([value, label]) => ({ label, value }));
+    }
+}
+
+export const ConnectionsSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: ConnectionsSettingsImpl,
+    dependencies: [ListModelsUseCase, ListModelsRepository]
+});

--- a/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
@@ -1,0 +1,130 @@
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+import { AI_MODEL_ROLE_DISPLAY } from "./modelRoles.js";
+import type { FormModel } from "@webiny/app-admin";
+
+interface ConnectionRow {
+    id: string;
+    name: string;
+    sdkName: string;
+}
+
+/**
+ * Three selects, and for most projects this is the whole AI configuration: one connection, one
+ * model per role. Everything else in these settings is opt-in.
+ */
+class ModelRolesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "modelRoles";
+    label = "Model roles";
+    description = "Which model does the cheap work, the main work, and the image work.";
+
+    constructor(
+        private useCase: ListModelsUseCase.Interface,
+        private repository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await this.useCase.execute();
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            roles: fields
+                .object()
+                .label("Roles")
+                .renderer("passthrough")
+                .fields(f =>
+                    Object.fromEntries(
+                        AI_MODEL_ROLE_DISPLAY.map(role => [
+                            role.id,
+                            f
+                                .object()
+                                .label(role.label)
+                                .renderer("objectAccordionSingle", {
+                                    itemTitle: role.label,
+                                    itemDescription: role.description,
+                                    open: true
+                                })
+                                .fields(rf => ({
+                                    connectionId: rf
+                                        .text()
+                                        .label("Connection")
+                                        .description("Which API key runs this role.")
+                                        .options(({ form }) => this.getConnectionOptions(form)),
+                                    model: rf
+                                        .text()
+                                        .label("Model")
+                                        .description(
+                                            "Only models from the selected connection's vendor are listed."
+                                        )
+                                        .disabledWhen(
+                                            ({ form }) => !this.getSelectedConnection(form, role.id)
+                                        )
+                                        .options(({ form }) => this.getModelOptions(form, role.id))
+                                }))
+                        ])
+                    )
+                )
+        }));
+
+        form.layout(layout => [layout.row("roles")]);
+    }
+
+    private getConnections(form: FormModel.Interface): ConnectionRow[] {
+        const data = form.getData() as {
+            connections?: { presets?: ConnectionRow[] };
+        };
+        return data.connections?.presets ?? [];
+    }
+
+    private getConnectionOptions(form: FormModel.Interface) {
+        return this.getConnections(form)
+            .filter(c => c.id && c.name)
+            .map(c => ({ label: c.name, value: c.id }));
+    }
+
+    private getSelectedConnection(
+        form: FormModel.Interface,
+        roleId: string
+    ): ConnectionRow | undefined {
+        const data = form.getData() as {
+            modelRoles?: { roles?: Record<string, { connectionId?: string }> };
+        };
+        const connectionId = data.modelRoles?.roles?.[roleId]?.connectionId;
+
+        if (!connectionId) {
+            return undefined;
+        }
+
+        return this.getConnections(form).find(c => c.id === connectionId);
+    }
+
+    /**
+     * Filtered by the chosen connection's vendor. Listing every model regardless would let someone
+     * pair an OpenAI model with an Anthropic key, which then fails at request time with a provider
+     * auth error that says nothing about the real mistake.
+     */
+    private getModelOptions(form: FormModel.Interface, roleId: string) {
+        const connection = this.getSelectedConnection(form, roleId);
+
+        if (!connection) {
+            return [];
+        }
+
+        return this.repository
+            .getModels()
+            .filter(model => model.providerId === connection.sdkName)
+            .map(model => ({
+                label: model.modelName,
+                value: `${model.providerId}/${model.modelId}`
+            }));
+    }
+}
+
+export const ModelRolesSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: ModelRolesSettingsImpl,
+    dependencies: [ListModelsUseCase, ListModelsRepository]
+});

--- a/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
@@ -43,9 +43,15 @@ class ModelRolesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
                             f
                                 .object()
                                 .label(role.label)
+                                /*
+                                 * Both callbacks, not strings. A string here is a *field name* to
+                                 * read the value from, not literal text, so passing prose made the
+                                 * renderer look for a child field called "Cheap, low-latency
+                                 * work..." and render no description at all.
+                                 */
                                 .renderer("objectAccordionSingle", {
-                                    itemTitle: role.label,
-                                    itemDescription: role.description,
+                                    itemTitle: () => role.label,
+                                    itemDescription: () => role.description,
                                     open: true
                                 })
                                 .fields(rf => ({

--- a/packages/ai-powerups/src/admin/presentation/WbContentGeneration/GenerateContentButton.tsx
+++ b/packages/ai-powerups/src/admin/presentation/WbContentGeneration/GenerateContentButton.tsx
@@ -3,13 +3,16 @@ import { IconButton } from "@webiny/admin-ui";
 import { ReactComponent as ChatIcon } from "@webiny/icons/auto_fix_high.svg";
 import { useOpenDialog } from "@webiny/app-admin";
 import { GENERATE_CONTENT_DIALOG } from "./GenerateContentDialog.js";
-import { useAiPowerUpsSettings } from "~/admin/presentation/AiPowerUpsSettings/index.js";
+import {
+    hasUsableModel,
+    useAiPowerUpsSettings
+} from "~/admin/presentation/AiPowerUpsSettings/index.js";
 
 export const GenerateContentButton = () => {
     const { openDialog } = useOpenDialog();
     const { settings } = useAiPowerUpsSettings();
 
-    if (!settings || settings.providers.presets.length === 0) {
+    if (!hasUsableModel(settings)) {
         return null;
     }
 

--- a/packages/ai-powerups/src/admin/presentation/modelRoles.ts
+++ b/packages/ai-powerups/src/admin/presentation/modelRoles.ts
@@ -1,0 +1,38 @@
+/**
+ * The model roles, as the settings screen presents them.
+ *
+ * The api owns the ids and the resolution rules (`~/api/features/ModelRoles/roles.ts`); this owns
+ * the words. The ids are repeated rather than imported because admin and api are separate bundles
+ * and nothing else in `src/admin` reaches across that line. Settings section names are already
+ * duplicated the same way.
+ *
+ * The set is closed by design, so a constant is safe: an extension can add a capability, never a
+ * role.
+ */
+export const AI_MODEL_ROLE_IDS = ["fast", "standard", "vision"] as const;
+
+export type AiModelRoleId = (typeof AI_MODEL_ROLE_IDS)[number];
+
+/** Typed as a full record, so adding a role id without a label is a compile error. */
+const ROLE_TEXT: Record<AiModelRoleId, { label: string; description: string }> = {
+    fast: {
+        label: "Fast",
+        description:
+            "Cheap, low-latency work where a smaller model is good enough: summarising, classifying, comparing."
+    },
+    standard: {
+        label: "Standard",
+        description:
+            "The workhorse. Anything that writes content a person will read, or has to follow a schema and call tools. Every other role falls back to this one when left empty."
+    },
+    vision: {
+        label: "Vision",
+        description:
+            "Work that reads images. Pick a model that accepts image input. Left empty, image features fall back to Standard and only work there if Standard is multimodal too."
+    }
+};
+
+export const AI_MODEL_ROLE_DISPLAY = AI_MODEL_ROLE_IDS.map(id => ({ id, ...ROLE_TEXT[id] }));
+
+export const roleLabel = (id: string): string =>
+    id in ROLE_TEXT ? ROLE_TEXT[id as AiModelRoleId].label : id;

--- a/packages/ai-powerups/src/api/Extension.ts
+++ b/packages/ai-powerups/src/api/Extension.ts
@@ -6,6 +6,9 @@ import { GetSettingsFeature } from "./features/GetSettings/feature.js";
 import { UpdateSettingsFeature } from "./features/UpdateSettings/feature.js";
 import { WbGeneratePageContentFeature } from "./features/WbGeneratePageContent/feature.js";
 import { ProvidersFeature } from "./features/Providers/feature.js";
+import { ConnectionsFeature } from "./features/Connections/feature.js";
+import { ModelRolesFeature } from "./features/ModelRoles/feature.js";
+import { CapabilitiesFeature } from "./features/Capabilities/feature.js";
 import { ReaderPersonasFeature } from "./features/ReaderPersonas/feature.js";
 import { WriterPersonasFeature } from "./features/WriterPersonas/feature.js";
 import { ProjectsFeature } from "./features/Projects/feature.js";
@@ -25,7 +28,15 @@ export const Extension = createFeature({
 
         GetSettingsFeature.register(container);
         UpdateSettingsFeature.register(container);
+        /*
+         * `ProvidersFeature` is still registered so the legacy `providers` section keeps round-
+         * tripping through storage. `Connections` and `ModelRoles` read it once to seed
+         * themselves; nothing else does. It goes away with the next breaking release.
+         */
         ProvidersFeature.register(container);
+        ConnectionsFeature.register(container);
+        ModelRolesFeature.register(container);
+        CapabilitiesFeature.register(container);
         ReaderPersonasFeature.register(container);
         WriterPersonasFeature.register(container);
         ProjectsFeature.register(container);

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/PrepareImageEnrichmentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/PrepareImageEnrichmentUseCase.ts
@@ -1,12 +1,15 @@
 import { Result } from "@webiny/feature/api";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetFileUseCase } from "@webiny/api-file-manager/features/file/GetFile/index.js";
 import { GetFileContentsByIdUseCase } from "@webiny/api-file-manager/features/file/GetFileContentsById/abstractions.js";
 import {
     PrepareImageEnrichmentUseCase as UseCaseAbstraction,
     type IPreparedImageEnrichment
 } from "./abstractions.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { FM_IMAGE_ENRICHMENT_CAPABILITY } from "./capability.js";
 import {
     EnrichmentFileContentsError,
     EnrichmentFileNotFoundError,
@@ -19,8 +22,7 @@ class PrepareImageEnrichmentUseCaseImpl implements UseCaseAbstraction.Interface 
     constructor(
         private getFile: GetFileUseCase.Interface,
         private getFileContents: GetFileContentsByIdUseCase.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
-        private encryption: Encryption.Interface
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface
     ) {}
 
     async execute(fileId: string): Promise<Result<IPreparedImageEnrichment, ImageEnrichmentError>> {
@@ -44,30 +46,25 @@ class PrepareImageEnrichmentUseCaseImpl implements UseCaseAbstraction.Interface 
             return Result.fail(new EnrichmentFileContentsError(contentsResult.error.message));
         }
 
-        const aiSettingsResult = await this.getSettings.execute();
-        if (aiSettingsResult.isFail()) {
-            return Result.fail(new EnrichmentNoProviderError());
+        const resolved = await this.resolveCapability.execute(FM_IMAGE_ENRICHMENT_CAPABILITY);
+        if (resolved.isFail()) {
+            return Result.fail(new EnrichmentNoProviderError(resolved.error.message));
         }
 
-        const firstProvider = aiSettingsResult.value.providers.presets[0];
-        if (!firstProvider) {
-            return Result.fail(new EnrichmentNoProviderError());
-        }
+        const capability = resolved.value;
 
         return Result.ok({
             fileId: file.id,
             imageBase64: contentsResult.value.buffer.toString("base64"),
             imageMediaType: contentsResult.value.contentType,
-            model: firstProvider.model,
-            connection: {
-                sdkName: firstProvider.model.split("/")[0],
-                apiKey: await this.encryption.decrypt(firstProvider.apiKeyEncrypted)
-            }
+            model: capability.model,
+            prompt: withAdditionalInstructions(capability.guidance, capability),
+            connection: capability.connection
         });
     }
 }
 
 export const PrepareImageEnrichmentUseCase = UseCaseAbstraction.createImplementation({
     implementation: PrepareImageEnrichmentUseCaseImpl,
-    dependencies: [GetFileUseCase, GetFileContentsByIdUseCase, GetSettingsUseCase, Encryption]
+    dependencies: [GetFileUseCase, GetFileContentsByIdUseCase, ResolveAiCapabilityUseCase]
 });

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/abstractions.ts
@@ -34,6 +34,12 @@ export interface IPreparedImageEnrichment {
     imageBase64: string;
     imageMediaType: string;
     model: string;
+    /**
+     * The resolved prompt: this capability's guidance (or the project's replacement for it) with
+     * the project's additional instructions appended. `AI_ENRICHMENT_PROMPT` is the default that
+     * feeds it, not what gets sent.
+     */
+    prompt: string;
     connection: {
         sdkName: string;
         apiKey: string;

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/buildEnrichmentAiRequest.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/buildEnrichmentAiRequest.ts
@@ -1,6 +1,6 @@
 import { Output } from "ai";
 import type { Ai } from "@webiny/api-core/features/ai/index.js";
-import { AI_ENRICHMENT_PROMPT, aiEnrichmentSchema } from "./abstractions.js";
+import { aiEnrichmentSchema } from "./abstractions.js";
 import type { IPreparedImageEnrichment } from "./abstractions.js";
 
 /**
@@ -32,7 +32,7 @@ export function buildEnrichmentAiRequest(
                     },
                     {
                         type: "text",
-                        text: AI_ENRICHMENT_PROMPT
+                        text: prepared.prompt
                     }
                 ]
             }

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
@@ -10,8 +10,9 @@ class FmImageEnrichmentCapabilityImpl implements AiCapability.Interface {
         "Reads an uploaded image and writes its alt text, title and tags. Needs a model that accepts image input.";
     readonly defaultRole = "vision" as const;
     /**
-     * Fixed text, and the field a project is most likely to want to change: tag vocabularies are
-     * house style ("use our taxonomy", "no more than three tags", "British spelling").
+     * The one prompt here whose structure does not come from the prose: `Output.object(...)` in
+     * `buildEnrichmentAiRequest` enforces the tags/description shape. Projects still adjust it by
+     * appending, which is where house tag vocabularies go ("use our taxonomy", "British spelling").
      */
     readonly guidance = AI_ENRICHMENT_PROMPT;
 }

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
@@ -1,0 +1,22 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+import { AI_ENRICHMENT_PROMPT } from "./abstractions.js";
+
+export const FM_IMAGE_ENRICHMENT_CAPABILITY = "fm.imageEnrichment";
+
+class FmImageEnrichmentCapabilityImpl implements AiCapability.Interface {
+    readonly id = FM_IMAGE_ENRICHMENT_CAPABILITY;
+    readonly label = "Image enrichment";
+    readonly description =
+        "Reads an uploaded image and writes its alt text, title and tags. Needs a model that accepts image input.";
+    readonly defaultRole = "vision" as const;
+    /**
+     * Fixed text, and the field a project is most likely to want to change: tag vocabularies are
+     * house style ("use our taxonomy", "no more than three tags", "British spelling").
+     */
+    readonly guidance = AI_ENRICHMENT_PROMPT;
+}
+
+export const FmImageEnrichmentCapability = AiCapability.createImplementation({
+    implementation: FmImageEnrichmentCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/errors.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/errors.ts
@@ -30,8 +30,16 @@ export class EnrichmentFileContentsError extends Error {
 export class EnrichmentNoProviderError extends Error {
     readonly code = "ENRICHMENT_NO_AI_PROVIDER" as const;
 
-    constructor() {
-        super("No AI provider configured. Add a provider in AI Power Ups settings.");
+    /**
+     * The reason comes from capability resolution, which knows which of the several ways this can
+     * fail actually happened: no model in the Vision role, a deleted connection, a missing key.
+     * Passing it through beats replacing all of them with one generic sentence.
+     */
+    constructor(reason?: string) {
+        super(
+            reason ??
+                "No AI model is configured for image enrichment. Pick one under Settings → AI Power-Ups → Model roles."
+        );
     }
 }
 

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/feature.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/feature.ts
@@ -5,6 +5,7 @@ import { AiImageEnrichmentTask } from "./AiImageEnrichmentTask.js";
 import { AiImageEnrichmentStreamRouteDefinition } from "./AiImageEnrichmentStreamRoute.js";
 import { PrepareImageEnrichmentUseCase } from "./PrepareImageEnrichmentUseCase.js";
 import { ApplyImageEnrichmentUseCase } from "./ApplyImageEnrichmentUseCase.js";
+import { FmImageEnrichmentCapability } from "./capability.js";
 
 export const AiImageEnrichmentFeature = createFeature({
     name: "AiPowerUps/AiImageEnrichment",
@@ -22,6 +23,9 @@ export const AiImageEnrichmentFeature = createFeature({
             return;
         }
 
+        // Registered inside the gate, so a project without the license does not get a settings
+        // row for a feature it cannot use.
+        container.register(FmImageEnrichmentCapability);
         container.register(PrepareImageEnrichmentUseCase);
         container.register(ApplyImageEnrichmentUseCase);
 

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
 import { AI_MODEL_ROLE_IDS } from "~/api/features/ModelRoles/index.js";
+import { AiCapability } from "./abstractions.js";
 import type { AiCapabilityOverride, CapabilitiesSettings, PersistedCapabilities } from "./types.js";
 
 /*
@@ -30,41 +31,54 @@ const isEmptyOverride = (override: AiCapabilityOverride): boolean =>
     !override.guidance?.trim();
 
 /**
- * Keeps `null` and `""` out of storage. The form sends both for untouched fields, and persisting
- * them would mean every capability the project never configured still occupies a key.
+ * Keeps values that mean "not set" out of storage. The form sends `null` for an untouched field and
+ * `false` for an untouched switch, and persisting those would mean every capability a project never
+ * configured still occupies a key.
  */
 const dropEmptyValues = (override: AiCapabilityOverride): AiCapabilityOverride =>
     Object.fromEntries(
         Object.entries(override).filter(
-            ([, value]) => value !== null && value !== undefined && value !== ""
+            ([, value]) => value !== null && value !== undefined && value !== "" && value !== false
         )
     ) as AiCapabilityOverride;
 
 /**
- * Drops a prompt the project has not actually taken ownership of.
+ * Drops a stored prompt that is just a copy of ours.
  *
  * The admin pre-fills the prompt textarea with our own text so that flipping the switch shows you
- * what you are about to edit. That default came back on every save, switch on or off, so three
- * capabilities ended up storing a verbatim copy of a prompt nobody had touched.
+ * what you are about to edit, and that default comes back on every save whether the switch is on or
+ * not. Persisting it is what we must not do: a stored copy is a *frozen* copy, so flipping the
+ * switch a year later would hand back whatever we shipped the day the row was written rather than
+ * the current prompt. That is the append-by-default trap arrived at from the other direction.
  *
- * Behaviour was still correct, because resolution ignores `guidance` unless `replacePrompt` is set.
- * The damage was subtler: a stored copy is a *frozen* copy. Flip the switch on a year later and you
- * would get whatever we shipped the day the row was first saved, not the current prompt, which is
- * the exact trap the append-by-default design exists to avoid. Storing it only on explicit opt-in
- * keeps "you own it from now on" true at the moment it starts being true.
+ * The test is whether the text differs from ours, not whether the switch is on. Keying off the
+ * switch looked equivalent and was not: it threw away a prompt somebody had actually written the
+ * moment they toggled the switch off and saved. Comparing content keeps that text, so toggling is
+ * lossless, while still refusing to store a default nobody chose.
  */
-const dropUnownedPrompt = (override: AiCapabilityOverride): AiCapabilityOverride => {
-    if (override.replacePrompt) {
+const dropEchoedPrompt = (
+    override: AiCapabilityOverride,
+    ownGuidance: string | undefined
+): AiCapabilityOverride => {
+    const stored = override.guidance?.trim();
+
+    if (!stored || stored !== (ownGuidance ?? "").trim()) {
         return override;
     }
 
-    const { guidance: _discarded, ...rest } = override;
+    const { guidance: _echoed, ...rest } = override;
     return rest;
 };
 
 class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
     readonly name = "capabilities";
     readonly inputSchema = inputSchema;
+
+    private ownGuidance: Map<string, string | undefined>;
+
+    constructor(capabilities: AiCapability.Interface[]) {
+        this.ownGuidance = new Map(capabilities.map(c => [c.id, c.guidance]));
+    }
 
     mapFromStorage(persisted: unknown): CapabilitiesSettings {
         const stored = (persisted ?? {}) as PersistedCapabilities;
@@ -81,7 +95,13 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
          */
         const entries = Object.entries(input.overrides ?? {})
             .filter(([, override]) => Boolean(override))
-            .map(([id, override]) => [id, dropUnownedPrompt(dropEmptyValues(override))] as const)
+            .map(
+                ([id, override]) =>
+                    [
+                        id,
+                        dropEchoedPrompt(dropEmptyValues(override), this.ownGuidance.get(id))
+                    ] as const
+            )
             .filter(([, override]) => !isEmptyOverride(override));
 
         return { overrides: Object.fromEntries(entries) };
@@ -90,5 +110,5 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
 
 export default AiPowerUpsSettingsGroupHandler.createImplementation({
     implementation: CapabilitiesHandlerImpl,
-    dependencies: []
+    dependencies: [[AiCapability, { multiple: true }]]
 });

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { AI_MODEL_ROLE_IDS } from "~/api/features/ModelRoles/index.js";
+import type { AiCapabilityOverride, CapabilitiesSettings, PersistedCapabilities } from "./types.js";
+
+const overrideSchema = z.object({
+    roleId: z.union([z.enum(AI_MODEL_ROLE_IDS), z.literal("")]).optional(),
+    connectionId: z.string().optional(),
+    model: z.string().optional(),
+    additionalInstructions: z.string().optional(),
+    replacePrompt: z.boolean().optional(),
+    guidance: z.string().optional()
+});
+
+const inputSchema = z.object({
+    overrides: z.record(z.string(), overrideSchema)
+});
+
+/** Keeps the persisted blob free of rows that only hold empty strings. */
+const isEmptyOverride = (override: AiCapabilityOverride): boolean =>
+    !override.roleId &&
+    !override.connectionId &&
+    !override.model &&
+    !override.additionalInstructions?.trim() &&
+    !override.replacePrompt &&
+    !override.guidance?.trim();
+
+class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "capabilities";
+    readonly inputSchema = inputSchema;
+
+    mapFromStorage(persisted: unknown): CapabilitiesSettings {
+        const stored = (persisted ?? {}) as PersistedCapabilities;
+        return { overrides: stored.overrides ?? {} };
+    }
+
+    async mapToStorage(internal: unknown): Promise<PersistedCapabilities> {
+        const input = internal as CapabilitiesSettings;
+        const entries = Object.entries(input.overrides ?? {}).filter(
+            ([, override]) => override && !isEmptyOverride(override)
+        );
+
+        return { overrides: Object.fromEntries(entries) };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: CapabilitiesHandlerImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -3,13 +3,17 @@ import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
 import { AI_MODEL_ROLE_IDS } from "~/api/features/ModelRoles/index.js";
 import type { AiCapabilityOverride, CapabilitiesSettings, PersistedCapabilities } from "./types.js";
 
+/*
+ * Every field here is empty by default and the admin form sends `null` for an untouched one, so
+ * each has to accept it. `mapToStorage` drops the nulls rather than persisting them.
+ */
 const overrideSchema = z.object({
-    roleId: z.union([z.enum(AI_MODEL_ROLE_IDS), z.literal("")]).optional(),
-    connectionId: z.string().optional(),
-    model: z.string().optional(),
-    additionalInstructions: z.string().optional(),
-    replacePrompt: z.boolean().optional(),
-    guidance: z.string().optional()
+    roleId: z.union([z.enum(AI_MODEL_ROLE_IDS), z.literal("")]).nullish(),
+    connectionId: z.string().nullish(),
+    model: z.string().nullish(),
+    additionalInstructions: z.string().nullish(),
+    replacePrompt: z.boolean().nullish(),
+    guidance: z.string().nullish()
 });
 
 const inputSchema = z.object({
@@ -25,6 +29,17 @@ const isEmptyOverride = (override: AiCapabilityOverride): boolean =>
     !override.replacePrompt &&
     !override.guidance?.trim();
 
+/**
+ * Keeps `null` and `""` out of storage. The form sends both for untouched fields, and persisting
+ * them would mean every capability the project never configured still occupies a key.
+ */
+const dropEmptyValues = (override: AiCapabilityOverride): AiCapabilityOverride =>
+    Object.fromEntries(
+        Object.entries(override).filter(
+            ([, value]) => value !== null && value !== undefined && value !== ""
+        )
+    ) as AiCapabilityOverride;
+
 class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
     readonly name = "capabilities";
     readonly inputSchema = inputSchema;
@@ -36,9 +51,10 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
 
     async mapToStorage(internal: unknown): Promise<PersistedCapabilities> {
         const input = internal as CapabilitiesSettings;
-        const entries = Object.entries(input.overrides ?? {}).filter(
-            ([, override]) => override && !isEmptyOverride(override)
-        );
+
+        const entries = Object.entries(input.overrides ?? {})
+            .filter(([, override]) => override && !isEmptyOverride(override))
+            .map(([id, override]) => [id, dropEmptyValues(override)] as const);
 
         return { overrides: Object.fromEntries(entries) };
     }

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -40,6 +40,28 @@ const dropEmptyValues = (override: AiCapabilityOverride): AiCapabilityOverride =
         )
     ) as AiCapabilityOverride;
 
+/**
+ * Drops a prompt the project has not actually taken ownership of.
+ *
+ * The admin pre-fills the prompt textarea with our own text so that flipping the switch shows you
+ * what you are about to edit. That default came back on every save, switch on or off, so three
+ * capabilities ended up storing a verbatim copy of a prompt nobody had touched.
+ *
+ * Behaviour was still correct, because resolution ignores `guidance` unless `replacePrompt` is set.
+ * The damage was subtler: a stored copy is a *frozen* copy. Flip the switch on a year later and you
+ * would get whatever we shipped the day the row was first saved, not the current prompt, which is
+ * the exact trap the append-by-default design exists to avoid. Storing it only on explicit opt-in
+ * keeps "you own it from now on" true at the moment it starts being true.
+ */
+const dropUnownedPrompt = (override: AiCapabilityOverride): AiCapabilityOverride => {
+    if (override.replacePrompt) {
+        return override;
+    }
+
+    const { guidance: _discarded, ...rest } = override;
+    return rest;
+};
+
 class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
     readonly name = "capabilities";
     readonly inputSchema = inputSchema;
@@ -52,9 +74,15 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
     async mapToStorage(internal: unknown): Promise<PersistedCapabilities> {
         const input = internal as CapabilitiesSettings;
 
+        /*
+         * Normalise before testing for emptiness, not after. A row holding nothing but the
+         * pre-filled prompt is empty once that prompt is discarded, and it should disappear rather
+         * than persist as an override of nothing.
+         */
         const entries = Object.entries(input.overrides ?? {})
-            .filter(([, override]) => override && !isEmptyOverride(override))
-            .map(([id, override]) => [id, dropEmptyValues(override)] as const);
+            .filter(([, override]) => Boolean(override))
+            .map(([id, override]) => [id, dropUnownedPrompt(dropEmptyValues(override))] as const)
+            .filter(([, override]) => !isEmptyOverride(override));
 
         return { overrides: Object.fromEntries(entries) };
     }

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
 import { AI_MODEL_ROLE_IDS } from "~/api/features/ModelRoles/index.js";
-import { AiCapability } from "./abstractions.js";
 import type { AiCapabilityOverride, CapabilitiesSettings, PersistedCapabilities } from "./types.js";
 
 /*
@@ -12,9 +11,7 @@ const overrideSchema = z.object({
     roleId: z.union([z.enum(AI_MODEL_ROLE_IDS), z.literal("")]).nullish(),
     connectionId: z.string().nullish(),
     model: z.string().nullish(),
-    additionalInstructions: z.string().nullish(),
-    replacePrompt: z.boolean().nullish(),
-    guidance: z.string().nullish()
+    additionalInstructions: z.string().nullish()
 });
 
 const inputSchema = z.object({
@@ -26,59 +23,22 @@ const isEmptyOverride = (override: AiCapabilityOverride): boolean =>
     !override.roleId &&
     !override.connectionId &&
     !override.model &&
-    !override.additionalInstructions?.trim() &&
-    !override.replacePrompt &&
-    !override.guidance?.trim();
+    !override.additionalInstructions?.trim();
 
 /**
- * Keeps values that mean "not set" out of storage. The form sends `null` for an untouched field and
- * `false` for an untouched switch, and persisting those would mean every capability a project never
- * configured still occupies a key.
+ * Keeps values that mean "not set" out of storage. The form sends `null` for an untouched field, and
+ * persisting those would mean every capability a project never configured still occupies a key.
  */
 const dropEmptyValues = (override: AiCapabilityOverride): AiCapabilityOverride =>
     Object.fromEntries(
         Object.entries(override).filter(
-            ([, value]) => value !== null && value !== undefined && value !== "" && value !== false
+            ([, value]) => value !== null && value !== undefined && value !== ""
         )
     ) as AiCapabilityOverride;
-
-/**
- * Drops a stored prompt that is just a copy of ours.
- *
- * The admin pre-fills the prompt textarea with our own text so that flipping the switch shows you
- * what you are about to edit, and that default comes back on every save whether the switch is on or
- * not. Persisting it is what we must not do: a stored copy is a *frozen* copy, so flipping the
- * switch a year later would hand back whatever we shipped the day the row was written rather than
- * the current prompt. That is the append-by-default trap arrived at from the other direction.
- *
- * The test is whether the text differs from ours, not whether the switch is on. Keying off the
- * switch looked equivalent and was not: it threw away a prompt somebody had actually written the
- * moment they toggled the switch off and saved. Comparing content keeps that text, so toggling is
- * lossless, while still refusing to store a default nobody chose.
- */
-const dropEchoedPrompt = (
-    override: AiCapabilityOverride,
-    ownGuidance: string | undefined
-): AiCapabilityOverride => {
-    const stored = override.guidance?.trim();
-
-    if (!stored || stored !== (ownGuidance ?? "").trim()) {
-        return override;
-    }
-
-    const { guidance: _echoed, ...rest } = override;
-    return rest;
-};
 
 class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
     readonly name = "capabilities";
     readonly inputSchema = inputSchema;
-
-    private ownGuidance: Map<string, string | undefined>;
-
-    constructor(capabilities: AiCapability.Interface[]) {
-        this.ownGuidance = new Map(capabilities.map(c => [c.id, c.guidance]));
-    }
 
     mapFromStorage(persisted: unknown): CapabilitiesSettings {
         const stored = (persisted ?? {}) as PersistedCapabilities;
@@ -88,20 +48,11 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
     async mapToStorage(internal: unknown): Promise<PersistedCapabilities> {
         const input = internal as CapabilitiesSettings;
 
-        /*
-         * Normalise before testing for emptiness, not after. A row holding nothing but the
-         * pre-filled prompt is empty once that prompt is discarded, and it should disappear rather
-         * than persist as an override of nothing.
-         */
+        // Normalise before testing for emptiness, so a row of untouched fields disappears rather
+        // than persisting as an override of nothing.
         const entries = Object.entries(input.overrides ?? {})
             .filter(([, override]) => Boolean(override))
-            .map(
-                ([id, override]) =>
-                    [
-                        id,
-                        dropEchoedPrompt(dropEmptyValues(override), this.ownGuidance.get(id))
-                    ] as const
-            )
+            .map(([id, override]) => [id, dropEmptyValues(override)] as const)
             .filter(([, override]) => !isEmptyOverride(override));
 
         return { overrides: Object.fromEntries(entries) };
@@ -110,5 +61,5 @@ class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interfac
 
 export default AiPowerUpsSettingsGroupHandler.createImplementation({
     implementation: CapabilitiesHandlerImpl,
-    dependencies: [[AiCapability, { multiple: true }]]
+    dependencies: []
 });

--- a/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
@@ -1,0 +1,184 @@
+import { Result } from "@webiny/feature/api";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import { sdkNameFromModel } from "~/api/features/Connections/index.js";
+import { AiCapability, ResolveAiCapabilityUseCase } from "./abstractions.js";
+import type { IResolvedAiCapability } from "./abstractions.js";
+import type { AiCapabilityOverride } from "./types.js";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+const SETTINGS_PATH = "Settings → AI Power-Ups";
+
+/**
+ * Turns a capability id into the model, credential and prompt text a use case needs.
+ *
+ * This is the single place that knows the precedence rules. Before it existed, six use cases each
+ * read `providers.presets[0]`, re-derived the SDK name from the model string and decrypted the key
+ * themselves, so "which model runs this feature" had six answers that only happened to agree.
+ *
+ * Precedence: a capability's pinned connection+model, else its chosen role, else its declared
+ * default role, else the `standard` role.
+ *
+ * There is deliberately no environment-variable fallback. A project whose settings say one thing
+ * and whose requests use another is the exact confusion this replaces.
+ */
+class ResolveAiCapabilityUseCaseImpl implements ResolveAiCapabilityUseCase.Interface {
+    private capabilityLookup: Map<string, AiCapability.Interface>;
+
+    constructor(
+        capabilities: AiCapability.Interface[],
+        private getSettings: GetSettingsUseCase.Interface,
+        private encryption: Encryption.Interface
+    ) {
+        this.capabilityLookup = new Map(capabilities.map(c => [c.id, c]));
+    }
+
+    async execute(capabilityId: string): Promise<Result<IResolvedAiCapability, Error>> {
+        const capability = this.capabilityLookup.get(capabilityId);
+
+        if (!capability) {
+            // Nothing a project can do about this one: the caller passed an unregistered id.
+            return Result.fail(
+                new Error(
+                    `Unknown AI capability "${capabilityId}". Register it with the AiCapability abstraction.`
+                )
+            );
+        }
+
+        const settingsResult = await this.getSettings.execute();
+        if (settingsResult.isFail()) {
+            return Result.fail(new Error("Failed to load AI Power-Ups settings."));
+        }
+
+        const settings = settingsResult.value;
+        const override: AiCapabilityOverride =
+            settings.capabilities?.overrides?.[capabilityId] ?? {};
+
+        const selection = this.selectModel(settings, capability.defaultRole, override);
+        if (selection.isFail()) {
+            return Result.fail(selection.error);
+        }
+
+        const { connectionId, model, roleId, fellBackToStandard } = selection.value;
+
+        const connection = settings.connections?.presets?.find(c => c.id === connectionId);
+
+        if (!connection) {
+            return Result.fail(
+                new Error(
+                    `"${capability.label}" points at a connection that no longer exists. Pick one under ${SETTINGS_PATH} → Model roles.`
+                )
+            );
+        }
+
+        if (!connection.apiKeyEncrypted) {
+            return Result.fail(
+                new Error(
+                    `The connection "${connection.name}" has no API key. Add one under ${SETTINGS_PATH} → Connections.`
+                )
+            );
+        }
+
+        /*
+         * A model is stored fully qualified ("anthropic/claude-sonnet-4-5") and a connection stores
+         * its vendor separately, so the two can disagree if a connection is re-pointed at another
+         * vendor after a role was filled. Catching it here beats a provider-side auth error.
+         */
+        const modelSdkName = sdkNameFromModel(model);
+        if (modelSdkName && connection.sdkName && modelSdkName !== connection.sdkName) {
+            return Result.fail(
+                new Error(
+                    `The model "${model}" cannot run on the "${connection.name}" connection, which is a ${connection.sdkName} credential. Fix the pairing under ${SETTINGS_PATH} → Model roles.`
+                )
+            );
+        }
+
+        return Result.ok({
+            capabilityId,
+            model,
+            connection: {
+                sdkName: modelSdkName || connection.sdkName,
+                apiKey: await this.encryption.decrypt(connection.apiKeyEncrypted)
+            },
+            roleId,
+            fellBackToStandard,
+            // The switch is what decides, not the presence of text. A project that turns the
+            // override off keeps its draft in settings but goes back to running Webiny's prompt.
+            guidance:
+                override.replacePrompt && override.guidance?.trim()
+                    ? override.guidance
+                    : (capability.guidance ?? ""),
+            additionalInstructions: override.additionalInstructions?.trim() ?? ""
+        });
+    }
+
+    private selectModel(
+        settings: IAiPowerUpsSettings,
+        defaultRole: AiModelRoleId,
+        override: AiCapabilityOverride
+    ): Result<
+        {
+            connectionId: string;
+            model: string;
+            roleId: AiModelRoleId | null;
+            fellBackToStandard: boolean;
+        },
+        Error
+    > {
+        // A pinned connection+model wins outright. Both halves are required; one alone is a
+        // half-finished edit, so it is ignored rather than guessed at.
+        if (override.connectionId && override.model) {
+            return Result.ok({
+                connectionId: override.connectionId,
+                model: override.model,
+                roleId: null,
+                fellBackToStandard: false
+            });
+        }
+
+        const roles = settings.modelRoles?.roles;
+        const requestedRole = (override.roleId || defaultRole) as AiModelRoleId;
+        const requested = roles?.[requestedRole];
+
+        if (requested?.connectionId && requested.model) {
+            return Result.ok({
+                connectionId: requested.connectionId,
+                model: requested.model,
+                roleId: requestedRole,
+                fellBackToStandard: false
+            });
+        }
+
+        /*
+         * An unfilled role falls back to `standard` rather than failing. That is what keeps an
+         * upgrade quiet: migration fills only `standard`, and every feature that used to read
+         * `providers.presets[0]` keeps running on exactly the model it ran on before.
+         *
+         * It does mean an unfilled `vision` role sends images to whatever `standard` holds. Same
+         * as today's behaviour, and the settings screen says so next to the role.
+         */
+        const standard = roles?.standard;
+
+        if (standard?.connectionId && standard.model) {
+            return Result.ok({
+                connectionId: standard.connectionId,
+                model: standard.model,
+                roleId: "standard",
+                fellBackToStandard: requestedRole !== "standard"
+            });
+        }
+
+        return Result.fail(
+            new Error(
+                `No model is configured for the "${requestedRole}" role. Pick one under ${SETTINGS_PATH} → Model roles.`
+            )
+        );
+    }
+}
+
+export const ResolveAiCapabilityUseCaseImplementation =
+    ResolveAiCapabilityUseCase.createImplementation({
+        implementation: ResolveAiCapabilityUseCaseImpl,
+        dependencies: [[AiCapability, { multiple: true }], GetSettingsUseCase, Encryption]
+    });

--- a/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
@@ -103,12 +103,9 @@ class ResolveAiCapabilityUseCaseImpl implements ResolveAiCapabilityUseCase.Inter
             },
             roleId,
             fellBackToStandard,
-            // The switch is what decides, not the presence of text. A project that turns the
-            // override off keeps its draft in settings but goes back to running Webiny's prompt.
-            guidance:
-                override.replacePrompt && override.guidance?.trim()
-                    ? override.guidance
-                    : (capability.guidance ?? ""),
+            // Always the capability's own. Projects adjust prompts by appending, never by
+            // replacing, because for most capabilities the prompt is the output contract.
+            guidance: capability.guidance ?? "",
             additionalInstructions: override.additionalInstructions?.trim() ?? ""
         });
     }

--- a/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
@@ -16,13 +16,13 @@ export interface IAiCapability {
     /** Which role supplies the model when the project has not overridden this capability. */
     readonly defaultRole: AiModelRoleId;
     /**
-     * The static system-prompt block, for capabilities whose prompt is a fixed piece of text a
-     * project could sensibly replace outright.
+     * The capability's fixed system-prompt block, owned by the code and not configurable.
      *
      * Leave it undefined when the prompt is assembled per request (from a content model schema, a
-     * component catalog, a persona). The settings screen then offers only "additional
-     * instructions", because offering a full replacement for a prompt the code rebuilds every call
-     * would just be a way to break generation.
+     * component catalog, a persona) and the use case builds its own system text instead.
+     *
+     * Either way a project can only append to it, via `additionalInstructions`. These prompts carry
+     * the output contract the surrounding code parses, so they are implementation, not settings.
      */
     readonly guidance?: string;
 }
@@ -45,7 +45,7 @@ export interface IResolvedAiCapability {
     roleId: AiModelRoleId | null;
     /** True when the requested role was empty and `standard` filled in for it. */
     fellBackToStandard: boolean;
-    /** The capability's guidance, or the project's replacement for it. */
+    /** The capability's own guidance. Empty when it assembles its prompt per request. */
     guidance: string;
     /** Project text to append to the system prompt. Empty when unset. */
     additionalInstructions: string;

--- a/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
@@ -1,0 +1,65 @@
+import { createAbstraction, Result } from "@webiny/feature/api";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+
+/**
+ * One AI feature, declared so the settings screen can list it and a project can point it at a
+ * different model or adjust its prompt.
+ *
+ * Features register these; nothing hardcodes the list. An extension that adds an AI feature gets a
+ * row in Settings for free by registering a capability alongside it.
+ */
+export interface IAiCapability {
+    /** Stable, namespaced, and persisted as a settings key. Renaming one orphans its overrides. */
+    readonly id: string;
+    readonly label: string;
+    readonly description: string;
+    /** Which role supplies the model when the project has not overridden this capability. */
+    readonly defaultRole: AiModelRoleId;
+    /**
+     * The static system-prompt block, for capabilities whose prompt is a fixed piece of text a
+     * project could sensibly replace outright.
+     *
+     * Leave it undefined when the prompt is assembled per request (from a content model schema, a
+     * component catalog, a persona). The settings screen then offers only "additional
+     * instructions", because offering a full replacement for a prompt the code rebuilds every call
+     * would just be a way to break generation.
+     */
+    readonly guidance?: string;
+}
+
+export const AiCapability = createAbstraction<IAiCapability>("AiPowerUpsAiCapability");
+
+export namespace AiCapability {
+    export type Interface = IAiCapability;
+}
+
+export interface IResolvedAiCapability {
+    capabilityId: string;
+    /** Fully qualified, e.g. `"anthropic/claude-sonnet-4-5"`. */
+    model: string;
+    connection: {
+        sdkName: string;
+        apiKey: string;
+    };
+    /** Which role supplied the model. `null` when a capability override pinned it directly. */
+    roleId: AiModelRoleId | null;
+    /** True when the requested role was empty and `standard` filled in for it. */
+    fellBackToStandard: boolean;
+    /** The capability's guidance, or the project's replacement for it. */
+    guidance: string;
+    /** Project text to append to the system prompt. Empty when unset. */
+    additionalInstructions: string;
+}
+
+export interface IResolveAiCapabilityUseCase {
+    execute(capabilityId: string): Promise<Result<IResolvedAiCapability, Error>>;
+}
+
+export const ResolveAiCapabilityUseCase = createAbstraction<IResolveAiCapabilityUseCase>(
+    "AiPowerUpsResolveAiCapabilityUseCase"
+);
+
+export namespace ResolveAiCapabilityUseCase {
+    export type Interface = IResolveAiCapabilityUseCase;
+    export type Resolution = IResolvedAiCapability;
+}

--- a/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
@@ -1,0 +1,26 @@
+import type { IResolvedAiCapability } from "./abstractions.js";
+
+/**
+ * Appends a project's additional instructions to a system prompt.
+ *
+ * Appending is the default way a project adjusts a prompt, and the reason is upgrades: a project
+ * that appends keeps getting our prompt improvements, while a project that replaces the prompt is
+ * frozen at whatever we shipped the day they edited it. The heading is there so the model reads the
+ * project's text as instructions rather than as more of ours.
+ */
+export const withAdditionalInstructions = (
+    systemText: string,
+    resolved: Pick<IResolvedAiCapability, "additionalInstructions">
+): string => {
+    if (!resolved.additionalInstructions) {
+        return systemText;
+    }
+
+    return `${systemText}
+
+### Project instructions
+
+These come from this project's settings and take precedence over the general guidance above.
+
+${resolved.additionalInstructions}`;
+};

--- a/packages/ai-powerups/src/api/features/Capabilities/feature.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/feature.ts
@@ -1,0 +1,11 @@
+import { createFeature } from "@webiny/feature/api";
+import CapabilitiesHandler from "./CapabilitiesHandler.js";
+import { ResolveAiCapabilityUseCaseImplementation } from "./ResolveAiCapabilityUseCase.js";
+
+export const CapabilitiesFeature = createFeature({
+    name: "AiPowerUpsCapabilities",
+    register(container) {
+        container.register(CapabilitiesHandler);
+        container.register(ResolveAiCapabilityUseCaseImplementation);
+    }
+});

--- a/packages/ai-powerups/src/api/features/Capabilities/index.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/index.ts
@@ -1,0 +1,5 @@
+export { AiCapability, ResolveAiCapabilityUseCase } from "./abstractions.js";
+export type { IAiCapability, IResolvedAiCapability } from "./abstractions.js";
+export { withAdditionalInstructions } from "./composeSystemPrompt.js";
+export type { AiCapabilityOverride, CapabilitiesSettings } from "./types.js";
+export { CapabilitiesFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/Capabilities/types.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/types.ts
@@ -1,0 +1,44 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+
+/**
+ * What a project changed about one capability. Every field is optional and empty by default: an
+ * untouched capability runs on its declared role with its declared prompt.
+ */
+export interface AiCapabilityOverride {
+    /** Run this capability on a different role. Empty means use the capability's default. */
+    roleId?: AiModelRoleId | "";
+    /** Pin an exact connection, bypassing roles entirely. Requires `model` too. */
+    connectionId?: string;
+    /** Pin an exact model. Only read when `connectionId` is also set. */
+    model?: string;
+    /** Appended to the system prompt. The safe option, and the one the UI shows by default. */
+    additionalInstructions?: string;
+    /**
+     * The explicit opt-in for owning this capability's prompt. Kept separate from `guidance` so
+     * switching it off restores Webiny's prompt without the project having to clear the text they
+     * wrote, and switching it back on returns them to it.
+     */
+    replacePrompt?: boolean;
+    /**
+     * Replaces the capability's own guidance, and only when `replacePrompt` is set. Offered only
+     * for capabilities that declare `guidance`, because a project that sets this stops receiving
+     * our prompt improvements for this capability.
+     */
+    guidance?: string;
+}
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        capabilities: {
+            /** Keyed by capability id. */
+            overrides: Record<string, AiCapabilityOverride>;
+        };
+    }
+}
+
+export type CapabilitiesSettings = IAiPowerUpsSettings["capabilities"];
+
+export interface PersistedCapabilities {
+    overrides?: Record<string, AiCapabilityOverride>;
+}

--- a/packages/ai-powerups/src/api/features/Capabilities/types.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/types.ts
@@ -12,20 +12,20 @@ export interface AiCapabilityOverride {
     connectionId?: string;
     /** Pin an exact model. Only read when `connectionId` is also set. */
     model?: string;
-    /** Appended to the system prompt. The safe option, and the one the UI shows by default. */
+    /**
+     * Appended to the capability's prompt.
+     *
+     * The only prompt customisation there is, and deliberately so. Replacing a prompt outright
+     * used to be offered here and is not any more: for most capabilities the prompt *is* the output
+     * contract the surrounding code parses, so replacing it means replacing part of the
+     * implementation. Revision comparison regex-matches the HTML table its prompt specifies, and
+     * page translation `JSON.parse`s a shape its prompt dictates, both failing silently if the
+     * format goes away. Appending leaves the contract in place.
+     *
+     * A project that genuinely needs different behaviour decorates the use case in code, which is
+     * how the AI translation itself is built.
+     */
     additionalInstructions?: string;
-    /**
-     * The explicit opt-in for owning this capability's prompt. Kept separate from `guidance` so
-     * switching it off restores Webiny's prompt without the project having to clear the text they
-     * wrote, and switching it back on returns them to it.
-     */
-    replacePrompt?: boolean;
-    /**
-     * Replaces the capability's own guidance, and only when `replacePrompt` is set. Offered only
-     * for capabilities that declare `guidance`, because a project that sets this stops receiving
-     * our prompt improvements for this capability.
-     */
-    guidance?: string;
 }
 
 declare module "~/api/types.js" {

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
@@ -1,68 +1,23 @@
 import { Ai } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { ModelToAstConverter } from "@webiny/api-headless-cms/features/contentModel/ModelToAstConverter/index.js";
 import { CmsModelToJsonSchemaConverter } from "@webiny/api-headless-cms/utils/contentModelToJsonSchema/index.js";
 import { GetRevisionByIdUseCase } from "@webiny/api-headless-cms/features/contentEntry/GetRevisionById/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY } from "./capability.js";
 import { CmsCompareEntryRevisionsUseCase } from "./abstractions.js";
 import type {
     ICmsCompareEntryRevisionsParams,
     ICmsCompareEntryRevisionsResult
 } from "./abstractions.js";
 
-const SYSTEM_PROMPT = `You are a content intelligence assistant specialized in version comparison for headless CMS platforms.
-
-I will provide:
-
-1. The content model JSON Schema that defines the structure of the entry.
-2. Two versions of the content entry values in JSON format: Version A and Version B.
-
-Your task:
-
-- Parse both versions according to the JSON Schema.
-- Identify all differences between Version A and Version B.
-- For each difference, explain:
-    - The field name (use the human-readable label from the schema description if available)
-    - The value in Version A
-    - The value in Version B
-    - A brief summary of the change (e.g., "Title changed from 'Old' to 'New'")
-- If nested fields or objects exist, perform a deep comparison.
-- Return the comparison in clean HTML format.
-
-Output format:
-
-<div class="comparison-report">
-    <table class="comparison-table">
-        <thead>
-            <tr>
-                <th>Field</th>
-                <th>Version A</th>
-                <th>Version B</th>
-                <th>Change Summary</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><strong>title</strong></td>
-                <td>Launch Plan</td>
-                <td>Updated Launch Plan</td>
-                <td>Title changed from 'Launch Plan' to 'Updated Launch Plan'</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-If no differences are found, return: <div class="no-changes"><h3>No differences detected between Version A and Version B.</h3></div>
-
-Use semantic HTML with appropriate CSS classes for styling. Do not include <style> tags or CSS — only return the HTML structure.
-For rich text or complex nested values, show a concise summary rather than raw JSON.`;
-
 class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUseCase.Interface {
     constructor(
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
-        private encryption: Encryption.Interface,
         private getModel: GetModelUseCase.Interface,
         private getRevisionById: GetRevisionByIdUseCase.Interface,
         private modelToAst: ModelToAstConverter.Interface
@@ -73,17 +28,14 @@ class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUse
     ): Promise<ICmsCompareEntryRevisionsResult> {
         const { modelId, revisionId1, revisionId2 } = params;
 
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            throw new Error("Failed to load AI Power Ups settings.");
+        const resolved = await this.resolveCapability.execute(
+            CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY
+        );
+        if (resolved.isFail()) {
+            throw resolved.error;
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            throw new Error("No AI provider configured. Add a provider in AI Power Ups settings.");
-        }
+        const capability = resolved.value;
 
         const modelResult = await this.getModel.execute(modelId);
         if (modelResult.isFail()) {
@@ -113,8 +65,6 @@ class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUse
             description: model.description
         });
 
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
-
         const userPrompt = `CONTENT MODEL JSON SCHEMA:
 ${JSON.stringify(entrySchema, null, 2)}
 
@@ -125,12 +75,9 @@ VERSION B (Revision #${revision2.version}):
 ${JSON.stringify(revision2.values, null, 2)}`;
 
         const result = await this.ai.generateText({
-            model: firstProvider.model,
-            connection: {
-                sdkName: firstProvider.model.split("/")[0],
-                apiKey
-            },
-            system: SYSTEM_PROMPT,
+            model: capability.model,
+            connection: capability.connection,
+            system: withAdditionalInstructions(capability.guidance, capability),
             prompt: userPrompt,
             temperature: 0.3
         });
@@ -159,9 +106,8 @@ export const CmsCompareEntryRevisionsUseCaseImplementation =
     CmsCompareEntryRevisionsUseCase.createImplementation({
         implementation: CmsCompareEntryRevisionsUseCaseImpl,
         dependencies: [
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
-            Encryption,
             GetModelUseCase,
             GetRevisionByIdUseCase,
             ModelToAstConverter

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
@@ -3,9 +3,9 @@ import { AiCapability } from "~/api/features/Capabilities/index.js";
 export const CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY = "cms.compareEntryRevisions";
 
 /**
- * The whole system prompt is fixed text, so a project can replace it outright. The output contract
- * lives in here too, which is exactly why replacing it is behind an opt-in: drop the HTML table
- * shape and the comparison dialog has nothing to render.
+ * The output contract lives in this prompt: the use case regex-matches the HTML table it specifies
+ * to build the summary, down to the literal "No differences detected" sentence and a count of
+ * `<tr>` tags, and the dialog styles those classes. That is why a project can only append to it.
  */
 const guidance = `You are a content intelligence assistant specialized in version comparison for headless CMS platforms.
 

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
@@ -1,0 +1,69 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY = "cms.compareEntryRevisions";
+
+/**
+ * The whole system prompt is fixed text, so a project can replace it outright. The output contract
+ * lives in here too, which is exactly why replacing it is behind an opt-in: drop the HTML table
+ * shape and the comparison dialog has nothing to render.
+ */
+const guidance = `You are a content intelligence assistant specialized in version comparison for headless CMS platforms.
+
+I will provide:
+
+1. The content model JSON Schema that defines the structure of the entry.
+2. Two versions of the content entry values in JSON format: Version A and Version B.
+
+Your task:
+
+- Parse both versions according to the JSON Schema.
+- Identify all differences between Version A and Version B.
+- For each difference, explain:
+    - The field name (use the human-readable label from the schema description if available)
+    - The value in Version A
+    - The value in Version B
+    - A brief summary of the change (e.g., "Title changed from 'Old' to 'New'")
+- If nested fields or objects exist, perform a deep comparison.
+- Return the comparison in clean HTML format.
+
+Output format:
+
+<div class="comparison-report">
+    <table class="comparison-table">
+        <thead>
+            <tr>
+                <th>Field</th>
+                <th>Version A</th>
+                <th>Version B</th>
+                <th>Change Summary</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>title</strong></td>
+                <td>Launch Plan</td>
+                <td>Updated Launch Plan</td>
+                <td>Title changed from 'Launch Plan' to 'Updated Launch Plan'</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+If no differences are found, return: <div class="no-changes"><h3>No differences detected between Version A and Version B.</h3></div>
+
+Use semantic HTML with appropriate CSS classes for styling. Do not include <style> tags or CSS — only return the HTML structure.
+For rich text or complex nested values, show a concise summary rather than raw JSON.`;
+
+class CmsCompareEntryRevisionsCapabilityImpl implements AiCapability.Interface {
+    readonly id = CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY;
+    readonly label = "CMS revision comparison";
+    readonly description =
+        "Summarises what changed between two revisions of an entry. Short, structural work that a smaller model handles well.";
+    readonly defaultRole = "fast" as const;
+    readonly guidance = guidance;
+}
+
+export const CmsCompareEntryRevisionsCapability = AiCapability.createImplementation({
+    implementation: CmsCompareEntryRevisionsCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/feature.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/feature.ts
@@ -1,9 +1,11 @@
 import { createFeature } from "@webiny/feature/api";
 import { CmsCompareEntryRevisionsUseCaseImplementation } from "./CmsCompareEntryRevisionsUseCase.js";
+import { CmsCompareEntryRevisionsCapability } from "./capability.js";
 
 export const CmsCompareEntryRevisionsFeature = createFeature({
     name: "AiPowerUps/CmsCompareEntryRevisions",
     register(container) {
+        container.register(CmsCompareEntryRevisionsCapability);
         container.register(CmsCompareEntryRevisionsUseCaseImplementation);
     }
 });

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
@@ -3,12 +3,15 @@ import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
 import { AiSdkTools } from "@webiny/api-core/features/ai/index.js";
 import { AiToolPipelineRunner } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { ListTagsUseCase } from "@webiny/api-file-manager/features/file/ListTags/index.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { ModelToAstConverter } from "@webiny/api-headless-cms/features/contentModel/ModelToAstConverter/index.js";
 import { CmsModelToJsonSchemaConverter } from "@webiny/api-headless-cms/utils/contentModelToJsonSchema/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { CMS_GENERATE_ENTRY_CAPABILITY } from "./capability.js";
 import {
     AiPromptContextBuilder,
     formatAdditionalFilesContext
@@ -27,10 +30,9 @@ import { injectDynamicZoneTypenames } from "./injectDynamicZoneTypenames.js";
 class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCase.Interface {
     constructor(
         private promptContextBuilder: AiPromptContextBuilder.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
         private aiSdkTools: AiSdkTools.Interface,
-        private encryption: Encryption.Interface,
         private listTags: ListTagsUseCase.Interface,
         private getModel: GetModelUseCase.Interface,
         private modelToAst: ModelToAstConverter.Interface,
@@ -40,19 +42,12 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
     async execute<TValues = Record<string, any>>(
         params: CmsGenerateEntryContentParams
     ): Promise<Result<GenerateEntryContentResult<TValues>, Error>> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            return Result.fail(new Error("Failed to load AI PowerUps settings."));
+        const resolved = await this.resolveCapability.execute(CMS_GENERATE_ENTRY_CAPABILITY);
+        if (resolved.isFail()) {
+            return Result.fail(resolved.error);
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return Result.fail(
-                new Error("No AI provider configured. Add a provider in AI Power Ups settings.")
-            );
-        }
+        const capability = resolved.value;
 
         const modelResult = await this.getModel.execute(params.modelId);
         if (modelResult.isFail()) {
@@ -67,7 +62,6 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
             description: model.description
         });
 
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
         const sdkTools = this.aiSdkTools.getToolSet();
 
         const context = await this.promptContextBuilder.execute({
@@ -92,8 +86,10 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
         });
         const imageTags = tagsResult.isOk() ? tagsResult.value.map(t => t.tag) : [];
 
-        const systemText =
-            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString();
+        const systemText = withAdditionalInstructions(
+            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString(),
+            capability
+        );
 
         const system = {
             role: "system" as const,
@@ -107,11 +103,8 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
 
         try {
             const aiResult = await this.ai.generateText({
-                model: firstProvider.model,
-                connection: {
-                    sdkName: firstProvider.model.split("/")[0],
-                    apiKey
-                },
+                model: capability.model,
+                connection: capability.connection,
                 system,
                 toolChoice: "auto",
                 prompt: params.prompt + formatAdditionalFilesContext(context.additionalFiles),
@@ -174,10 +167,9 @@ export const CmsGenerateEntryContentUseCaseImplementation =
         implementation: CmsGenerateEntryContentUseCaseImpl,
         dependencies: [
             AiPromptContextBuilder,
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
             AiSdkTools,
-            Encryption,
             ListTagsUseCase,
             GetModelUseCase,
             ModelToAstConverter,

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/capability.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/capability.ts
@@ -1,0 +1,21 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const CMS_GENERATE_ENTRY_CAPABILITY = "cms.generateEntry";
+
+/**
+ * No `guidance`: this prompt is rebuilt on every request from the content model's JSON Schema and
+ * the File Manager's current image tags, so there is no fixed block a project could replace without
+ * dropping the schema the output has to conform to. Additional instructions still apply.
+ */
+class CmsGenerateEntryCapabilityImpl implements AiCapability.Interface {
+    readonly id = CMS_GENERATE_ENTRY_CAPABILITY;
+    readonly label = "CMS entry generation";
+    readonly description =
+        "Writes a content entry from a prompt, following the content model's schema and picking images from the File Manager.";
+    readonly defaultRole = "standard" as const;
+}
+
+export const CmsGenerateEntryCapability = AiCapability.createImplementation({
+    implementation: CmsGenerateEntryCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/feature.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { CmsGenerateEntryContentUseCaseImplementation } from "./CmsGenerateEntryContentUseCase.js";
 import { CmsGenerateEntryContentTask } from "./CmsGenerateEntryContentTask.js";
+import { CmsGenerateEntryCapability } from "./capability.js";
 
 export const CmsGenerateEntryContentFeature = createFeature({
     name: "AiPowerUps/CmsGenerateEntryContent",
     register(container) {
+        container.register(CmsGenerateEntryCapability);
         container.register(CmsGenerateEntryContentUseCaseImplementation);
         container.register(CmsGenerateEntryContentTask);
     }

--- a/packages/ai-powerups/src/api/features/Connections/ConnectionsGraphQLMapper.ts
+++ b/packages/ai-powerups/src/api/features/Connections/ConnectionsGraphQLMapper.ts
@@ -1,0 +1,56 @@
+import { AiPowerUpsSettingsGroupGraphQLMapper } from "~/api/features/shared/index.js";
+import type { ConnectionsSettings } from "./types.js";
+
+interface ApiConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKey: string | null;
+}
+
+interface ApiConnections {
+    presets: ApiConnectionPreset[];
+}
+
+interface ApiInputConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKey?: string;
+}
+
+class ConnectionsGraphQLMapperImpl implements AiPowerUpsSettingsGroupGraphQLMapper.Interface {
+    readonly name = "connections";
+
+    toApi(internal: unknown): ApiConnections {
+        const data = internal as ConnectionsSettings;
+        return {
+            presets: data.presets.map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: p.sdkName,
+                // The admin form only ever sees the mask. The plaintext key never leaves the api.
+                apiKey: p.apiKeyMasked ?? null
+            }))
+        };
+    }
+
+    fromApi(api: unknown): ConnectionsSettings {
+        const data = api as { presets: ApiInputConnectionPreset[] };
+        return {
+            presets: data.presets.map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: p.sdkName,
+                apiKey: p.apiKey,
+                apiKeyMasked: "",
+                apiKeyEncrypted: ""
+            }))
+        };
+    }
+}
+
+export default AiPowerUpsSettingsGroupGraphQLMapper.createImplementation({
+    implementation: ConnectionsGraphQLMapperImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
+++ b/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { Masker } from "@webiny/api-core/features/masker/index.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { readLegacyProviderPresets, sdkNameFromModel } from "./types.js";
+import type {
+    ConnectionsSettings,
+    PersistedAiConnectionPreset,
+    PersistedConnections
+} from "./types.js";
+
+const inputSchema = z.object({
+    presets: z.array(
+        z.object({
+            id: z.string().min(1),
+            name: z.string().min(1),
+            sdkName: z.string().min(1),
+            apiKey: z.string().optional()
+        })
+    )
+});
+
+class ConnectionsHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "connections";
+    readonly inputSchema = inputSchema;
+
+    constructor(
+        private encryption: Encryption.Interface,
+        private masker: Masker.Interface
+    ) {}
+
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): ConnectionsSettings {
+        if (persisted && typeof persisted === "object") {
+            const data = persisted as PersistedConnections;
+            return {
+                presets: (data.presets ?? []).map(p => ({
+                    id: p.id,
+                    name: p.name,
+                    sdkName: p.sdkName,
+                    apiKeyMasked: p.apiKeyMasked ?? "",
+                    apiKeyEncrypted: p.apiKeyEncrypted ?? ""
+                }))
+            };
+        }
+
+        /*
+         * No `connections` section yet, so derive one from the legacy `providers` presets. The keys
+         * are already encrypted in storage, which is why this can be a pure read: nothing has to be
+         * re-encrypted, and nothing is written back until the next save.
+         *
+         * Dropping the model here is safe. `ModelRoles` reads the same legacy section and lifts
+         * the first preset's model into the `standard` role, which is the only model the old code
+         * ever used.
+         */
+        return {
+            presets: readLegacyProviderPresets(all).map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: sdkNameFromModel(p.model),
+                apiKeyMasked: p.apiKeyMasked ?? "",
+                apiKeyEncrypted: p.apiKeyEncrypted ?? ""
+            }))
+        };
+    }
+
+    async mapToStorage(internal: unknown, existing: unknown | null): Promise<PersistedConnections> {
+        const input = internal as ConnectionsSettings;
+        const existingPresets = (existing as ConnectionsSettings | null)?.presets ?? [];
+
+        const presets: PersistedAiConnectionPreset[] = await Promise.all(
+            input.presets.map(async preset => {
+                const existingMatch = existingPresets.find(ep => ep.id === preset.id);
+
+                let apiKeyEncrypted: string;
+                let apiKeyMasked: string;
+
+                if (!preset.apiKey || preset.apiKey === existingMatch?.apiKeyMasked) {
+                    // The form sends back the mask when the key was left alone. Carry it forward.
+                    apiKeyEncrypted = existingMatch?.apiKeyEncrypted ?? "";
+                    apiKeyMasked = existingMatch?.apiKeyMasked ?? "";
+                } else {
+                    apiKeyEncrypted = await this.encryption.encrypt(preset.apiKey);
+                    apiKeyMasked = this.masker.mask(preset.apiKey, [8, 4]);
+                }
+
+                return {
+                    id: preset.id,
+                    name: preset.name,
+                    sdkName: preset.sdkName,
+                    apiKeyEncrypted,
+                    apiKeyMasked
+                };
+            })
+        );
+
+        return { presets };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: ConnectionsHandlerImpl,
+    dependencies: [Encryption, Masker]
+});

--- a/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
+++ b/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
@@ -15,7 +15,7 @@ const inputSchema = z.object({
             id: z.string().min(1),
             name: z.string().min(1),
             sdkName: z.string().min(1),
-            apiKey: z.string().optional()
+            apiKey: z.string().nullish()
         })
     )
 });

--- a/packages/ai-powerups/src/api/features/Connections/feature.ts
+++ b/packages/ai-powerups/src/api/features/Connections/feature.ts
@@ -1,0 +1,11 @@
+import { createFeature } from "@webiny/feature/api";
+import ConnectionsHandler from "./ConnectionsHandler.js";
+import ConnectionsGraphQLMapper from "./ConnectionsGraphQLMapper.js";
+
+export const ConnectionsFeature = createFeature({
+    name: "AiPowerUpsConnections",
+    register(container) {
+        container.register(ConnectionsHandler);
+        container.register(ConnectionsGraphQLMapper);
+    }
+});

--- a/packages/ai-powerups/src/api/features/Connections/index.ts
+++ b/packages/ai-powerups/src/api/features/Connections/index.ts
@@ -1,0 +1,3 @@
+export type { AiConnectionPreset, ConnectionsSettings } from "./types.js";
+export { sdkNameFromModel } from "./types.js";
+export { ConnectionsFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/Connections/types.ts
+++ b/packages/ai-powerups/src/api/features/Connections/types.ts
@@ -1,0 +1,66 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+/**
+ * A connection is one credential for one vendor. It carries no model.
+ *
+ * The section it replaces (`providers`) bundled a key with a single model, so a project that wanted
+ * two Anthropic models had to paste the same key twice and keep both copies in sync. Splitting the
+ * two means the key is entered once and every model that vendor offers is then selectable.
+ */
+export interface AiConnectionPreset {
+    id: string;
+    name: string;
+    /** AI SDK namespace, e.g. "anthropic" or "openai". Matches `AiSdkFactory.id`. */
+    sdkName: string;
+    /** Plaintext. Only ever set on the way in from the admin form, never persisted. */
+    apiKey?: string;
+    apiKeyMasked: string;
+    apiKeyEncrypted: string;
+}
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        connections: {
+            presets: AiConnectionPreset[];
+        };
+    }
+}
+
+export type ConnectionsSettings = IAiPowerUpsSettings["connections"];
+
+export interface PersistedAiConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKeyEncrypted: string;
+    apiKeyMasked: string;
+}
+
+export interface PersistedConnections {
+    presets: PersistedAiConnectionPreset[];
+}
+
+/** Shape of a preset in the legacy `providers` section, read once for migration. */
+export interface LegacyProviderPreset {
+    id: string;
+    name: string;
+    model?: string;
+    apiKeyEncrypted?: string;
+    apiKeyMasked?: string;
+}
+
+export const readLegacyProviderPresets = (
+    all: Record<string, unknown> | undefined
+): LegacyProviderPreset[] => {
+    const providers = all?.["providers"];
+    if (!providers || typeof providers !== "object") {
+        return [];
+    }
+
+    const presets = (providers as { presets?: unknown }).presets;
+    return Array.isArray(presets) ? (presets as LegacyProviderPreset[]) : [];
+};
+
+/** `"anthropic/claude-sonnet-4-5"` -> `"anthropic"`. */
+export const sdkNameFromModel = (model: string | undefined): string =>
+    (model ?? "").split("/")[0] ?? "";

--- a/packages/ai-powerups/src/api/features/GetSettings/GetSettingsRepository.ts
+++ b/packages/ai-powerups/src/api/features/GetSettings/GetSettingsRepository.ts
@@ -30,7 +30,7 @@ class GetSettingsRepositoryImpl implements GetSettingsRepository.Interface {
         const result: Record<string, unknown> = {};
 
         for (const handler of this.handlers) {
-            result[handler.name] = handler.mapFromStorage(raw[handler.name]);
+            result[handler.name] = handler.mapFromStorage(raw[handler.name], raw);
         }
 
         for (const key of Object.keys(raw)) {

--- a/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
@@ -5,9 +5,16 @@ import { AI_MODEL_ROLE_IDS } from "./roles.js";
 import { emptyAssignment } from "./types.js";
 import type { AiModelRoleAssignments, ModelRolesSettings, PersistedModelRoles } from "./types.js";
 
+/*
+ * The admin form sends `null`, not `""`, for a field nobody has touched, and an unfilled role is
+ * the normal state of two of the three. `nullish` keeps an untouched role from failing validation;
+ * `mapToStorage` is what normalises it to `""`.
+ */
+const formString = z.string().nullish();
+
 const assignmentSchema = z.object({
-    connectionId: z.string(),
-    model: z.string()
+    connectionId: formString,
+    model: formString
 });
 
 const inputSchema = z.object({

--- a/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { readLegacyProviderPresets } from "~/api/features/Connections/types.js";
+import { AI_MODEL_ROLE_IDS } from "./roles.js";
+import { emptyAssignment } from "./types.js";
+import type { AiModelRoleAssignments, ModelRolesSettings, PersistedModelRoles } from "./types.js";
+
+const assignmentSchema = z.object({
+    connectionId: z.string(),
+    model: z.string()
+});
+
+const inputSchema = z.object({
+    roles: z.object(
+        Object.fromEntries(AI_MODEL_ROLE_IDS.map(id => [id, assignmentSchema]))
+    ) as unknown as z.ZodType<AiModelRoleAssignments>
+});
+
+class ModelRolesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "modelRoles";
+    readonly inputSchema = inputSchema;
+
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): ModelRolesSettings {
+        const stored = (persisted ?? {}) as PersistedModelRoles;
+        const roles = Object.fromEntries(
+            AI_MODEL_ROLE_IDS.map(id => {
+                const assignment = stored.roles?.[id];
+                return [
+                    id,
+                    {
+                        connectionId: assignment?.connectionId ?? "",
+                        model: assignment?.model ?? ""
+                    }
+                ];
+            })
+        ) as AiModelRoleAssignments;
+
+        if (roles.standard.model) {
+            return { roles };
+        }
+
+        /*
+         * Nothing has filled `standard` yet, so seed it from the legacy `providers` section. Every
+         * AI feature used to read `providers.presets[0]` and nothing else, so lifting exactly that
+         * preset into `standard` reproduces the old behaviour for a project that upgrades without
+         * touching the settings screen.
+         *
+         * `fast` and `vision` stay empty on purpose. Both fall back to `standard` at resolve time,
+         * so an untouched project keeps working, and the settings screen shows the fallback rather
+         * than pretending someone chose it.
+         */
+        const legacy = readLegacyProviderPresets(all)[0];
+
+        if (legacy?.model) {
+            roles.standard = { connectionId: legacy.id, model: legacy.model };
+        }
+
+        return { roles };
+    }
+
+    async mapToStorage(internal: unknown): Promise<PersistedModelRoles> {
+        const input = internal as ModelRolesSettings;
+
+        return {
+            roles: Object.fromEntries(
+                AI_MODEL_ROLE_IDS.map(id => {
+                    const assignment = input.roles?.[id] ?? emptyAssignment();
+                    return [
+                        id,
+                        {
+                            connectionId: assignment.connectionId ?? "",
+                            model: assignment.model ?? ""
+                        }
+                    ];
+                })
+            )
+        };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: ModelRolesHandlerImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/ModelRoles/feature.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import ModelRolesHandler from "./ModelRolesHandler.js";
+
+export const ModelRolesFeature = createFeature({
+    name: "AiPowerUpsModelRoles",
+    register(container) {
+        container.register(ModelRolesHandler);
+    }
+});

--- a/packages/ai-powerups/src/api/features/ModelRoles/index.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/index.ts
@@ -1,0 +1,4 @@
+export { AI_MODEL_ROLE_IDS, isAiModelRoleId } from "./roles.js";
+export type { AiModelRoleId } from "./roles.js";
+export type { AiModelRoleAssignment, AiModelRoleAssignments, ModelRolesSettings } from "./types.js";
+export { ModelRolesFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/ModelRoles/roles.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/roles.ts
@@ -1,0 +1,19 @@
+/**
+ * Model roles are the indirection between an AI feature and a concrete model.
+ *
+ * A feature never names a model. It names a role, and the project decides which model fills that
+ * role. That keeps the settings screen small (one select per role, not one per feature) while still
+ * letting a project run cheap work on a cheap model.
+ *
+ * The set is deliberately fixed and closed. A project that needs a different model for one specific
+ * feature overrides that feature under Capabilities instead of inventing a role.
+ *
+ * Labels and descriptions are not here on purpose: they are UI text, and they live next to the
+ * settings form in `~/admin/presentation/modelRoles.js`.
+ */
+export const AI_MODEL_ROLE_IDS = ["fast", "standard", "vision"] as const;
+
+export type AiModelRoleId = (typeof AI_MODEL_ROLE_IDS)[number];
+
+export const isAiModelRoleId = (value: unknown): value is AiModelRoleId =>
+    typeof value === "string" && (AI_MODEL_ROLE_IDS as readonly string[]).includes(value);

--- a/packages/ai-powerups/src/api/features/ModelRoles/types.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/types.ts
@@ -1,0 +1,27 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+import type { AiModelRoleId } from "./roles.js";
+
+export interface AiModelRoleAssignment {
+    /** Empty string means the role is unfilled. */
+    connectionId: string;
+    /** Fully qualified, e.g. `"anthropic/claude-sonnet-4-5"`. Empty string means unfilled. */
+    model: string;
+}
+
+export type AiModelRoleAssignments = Record<AiModelRoleId, AiModelRoleAssignment>;
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        modelRoles: {
+            roles: AiModelRoleAssignments;
+        };
+    }
+}
+
+export type ModelRolesSettings = IAiPowerUpsSettings["modelRoles"];
+
+export interface PersistedModelRoles {
+    roles?: Partial<Record<string, Partial<AiModelRoleAssignment>>>;
+}
+
+export const emptyAssignment = (): AiModelRoleAssignment => ({ connectionId: "", model: "" });

--- a/packages/ai-powerups/src/api/features/UpdateSettings/UpdateSettingsRepository.ts
+++ b/packages/ai-powerups/src/api/features/UpdateSettings/UpdateSettingsRepository.ts
@@ -31,7 +31,14 @@ class UpdateSettingsRepositoryImpl implements UpdateSettingsRepository.Interface
 
         const existingInternal: Record<string, unknown> = {};
         for (const handler of this.handlers) {
-            existingInternal[handler.name] = handler.mapFromStorage(raw[handler.name]);
+            /*
+             * `raw` matters here as much as it does on read. `connections` derives itself from the
+             * legacy `providers` section until it has one of its own, and this is what
+             * `mapToStorage` diffs against to carry forward an encrypted key the form only ever saw
+             * as a mask. Without it, the first save after an upgrade compares against an empty list
+             * and silently drops every stored key.
+             */
+            existingInternal[handler.name] = handler.mapFromStorage(raw[handler.name], raw);
         }
 
         const newSettings = input as unknown as Record<string, unknown>;

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
@@ -2,9 +2,12 @@ import { stepCountIs } from "ai";
 import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
 import { AiSdkTools } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { ListTagsUseCase } from "@webiny/api-file-manager/features/file/ListTags/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { WB_GENERATE_PAGE_CAPABILITY } from "./capability.js";
 import {
     AiPromptContextBuilder,
     formatAdditionalFilesContext
@@ -23,31 +26,21 @@ import { ComponentFilter } from "./ComponentFilter.js";
 class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.Interface {
     constructor(
         private promptContextBuilder: AiPromptContextBuilder.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
         private aiSdkTools: AiSdkTools.Interface,
-        private encryption: Encryption.Interface,
         private listTags: ListTagsUseCase.Interface
     ) {}
 
     async execute(
         params: WbGeneratePageContentParams
     ): Promise<Result<GeneratePageContentResult, Error>> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            return Result.fail(new Error("Failed to load AI PowerUps settings."));
+        const resolved = await this.resolveCapability.execute(WB_GENERATE_PAGE_CAPABILITY);
+        if (resolved.isFail()) {
+            return Result.fail(resolved.error);
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return Result.fail(
-                new Error("No AI provider configured. Add a provider in AI Power Ups settings.")
-            );
-        }
-
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
+        const capability = resolved.value;
 
         const sdkTools = this.aiSdkTools.getToolSet();
 
@@ -76,8 +69,10 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
         const imageTags = tagsResult.isOk() ? tagsResult.value.map(t => t.tag) : [];
 
         const components = params.components as Array<{ name: string }>;
-        const systemText =
-            buildDomainPrompt(components, params.tools, imageTags) + context.toString();
+        const systemText = withAdditionalInstructions(
+            buildDomainPrompt(components, params.tools, imageTags) + context.toString(),
+            capability
+        );
 
         const system = {
             role: "system" as const,
@@ -91,11 +86,8 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
 
         try {
             const aiResult = await this.ai.generateText({
-                model: firstProvider.model,
-                connection: {
-                    sdkName: firstProvider.model.split("/")[0],
-                    apiKey
-                },
+                model: capability.model,
+                connection: capability.connection,
                 system,
                 toolChoice: "auto",
                 prompt: params.prompt + formatAdditionalFilesContext(context.additionalFiles),
@@ -151,10 +143,9 @@ export const WbGeneratePageContentUseCaseImplementation =
         implementation: WbGeneratePageContentUseCaseImpl,
         dependencies: [
             AiPromptContextBuilder,
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
             AiSdkTools,
-            Encryption,
             ListTagsUseCase
         ]
     });

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/capability.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/capability.ts
@@ -1,0 +1,20 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const WB_GENERATE_PAGE_CAPABILITY = "wb.generatePage";
+
+/**
+ * No `guidance`, for the same reason as CMS entry generation: the prompt carries the component
+ * catalog and the tool definitions, both computed per request.
+ */
+class WbGeneratePageCapabilityImpl implements AiCapability.Interface {
+    readonly id = WB_GENERATE_PAGE_CAPABILITY;
+    readonly label = "Page generation";
+    readonly description =
+        "Writes page content from a prompt using the Website Builder components available in the project.";
+    readonly defaultRole = "standard" as const;
+}
+
+export const WbGeneratePageCapability = AiCapability.createImplementation({
+    implementation: WbGeneratePageCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/feature.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { WbGeneratePageContentUseCaseImplementation } from "./WbGeneratePageContentUseCase.js";
 import { WbGeneratePageContentTask } from "./WbGeneratePageContentTask.js";
+import { WbGeneratePageCapability } from "./capability.js";
 
 export const WbGeneratePageContentFeature = createFeature({
     name: "AiPowerUps/WbGeneratePageContent",
     register(container) {
+        container.register(WbGeneratePageCapability);
         container.register(WbGeneratePageContentUseCaseImplementation);
         container.register(WbGeneratePageContentTask);
     }

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
@@ -1,12 +1,15 @@
 import set from "lodash/set";
 import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetDefaultLanguageUseCase } from "@webiny/languages/exports/api/languages.js";
 import { TranslatePageUseCase } from "@webiny/api-website-builder/features/pages/TranslatePage/index.js";
 import { UpdatePageRepository } from "@webiny/api-website-builder/features/pages/UpdatePage/abstractions.js";
 import type { WbPage } from "@webiny/api-website-builder/domain/page/abstractions.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { WB_TRANSLATE_PAGE_CAPABILITY } from "./capability.js";
 import { LexicalParser } from "./abstractions/LexicalParser.js";
 
 type InputType = "text" | "longText" | "lexical";
@@ -30,9 +33,8 @@ interface TranslatedData {
 class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
     constructor(
         private getDefaultLanguage: GetDefaultLanguageUseCase.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
-        private encryption: Encryption.Interface,
         private lexicalParser: LexicalParser.Interface,
         private updatePageRepository: UpdatePageRepository.Interface,
         private decoratee: TranslatePageUseCase.Interface
@@ -79,19 +81,24 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         sourceLanguage: string,
         targetLanguage: string
     ): Promise<TranslatedData | null> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
+        const resolved = await this.resolveCapability.execute(WB_TRANSLATE_PAGE_CAPABILITY);
+        if (resolved.isFail()) {
+            /*
+             * Translation is a decorator on top of a successful page save, so it stays
+             * non-fatal: the page is already created, just untranslated. It does get logged
+             * now, because a silently skipped translation was indistinguishable from a
+             * misconfigured one.
+             */
+            console.error(
+                JSON.stringify({
+                    message: "Skipping AI page translation.",
+                    reason: resolved.error.message
+                })
+            );
             return null;
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return null;
-        }
-
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
+        const capability = resolved.value;
 
         const properties = {
             title: page.properties["title"],
@@ -102,12 +109,9 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         const input = JSON.stringify({ properties, bindings });
 
         const result = await this.ai.generateText({
-            model: firstProvider.model,
-            connection: {
-                sdkName: firstProvider.model.split("/")[0],
-                apiKey
-            },
-            system: `You are a professional translator. Translate all user-provided text to language code "${targetLanguage}", preserving placeholders and formatting. Return a JSON object with the same keys, only changing the values.`,
+            model: capability.model,
+            connection: capability.connection,
+            system: withAdditionalInstructions(capability.guidance, capability),
             prompt: `Translate given key-value pairs from "${sourceLanguage}" to language code "${targetLanguage}". Do not modify the keys. "properties" is a simple key-value pair. "bindings" values are located in the "value" key. ${input}`,
             temperature: 0.3
         });
@@ -199,9 +203,8 @@ export const WbTranslatePageDecorator = TranslatePageUseCase.createDecorator({
     decorator: WbTranslatePageDecoratorImpl,
     dependencies: [
         GetDefaultLanguageUseCase,
-        GetSettingsUseCase,
+        ResolveAiCapabilityUseCase,
         Ai,
-        Encryption,
         LexicalParser,
         UpdatePageRepository
     ]

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/capability.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/capability.ts
@@ -1,0 +1,26 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const WB_TRANSLATE_PAGE_CAPABILITY = "wb.translatePage";
+
+/**
+ * The target language used to be interpolated into this sentence. It moved to the user prompt so
+ * the instructions could become fixed text a project can replace, which is worth doing here: house
+ * translation rules (keep product names in English, use formal address, never translate these
+ * twelve terms) are the most commonly requested prompt change in the whole feature set.
+ */
+const guidance =
+    "You are a professional translator. Translate all user-provided text to the requested target language, preserving placeholders and formatting. Return a JSON object with the same keys, only changing the values.";
+
+class WbTranslatePageCapabilityImpl implements AiCapability.Interface {
+    readonly id = WB_TRANSLATE_PAGE_CAPABILITY;
+    readonly label = "Page translation";
+    readonly description =
+        "Translates the text on a page into another language, preserving placeholders.";
+    readonly defaultRole = "standard" as const;
+    readonly guidance = guidance;
+}
+
+export const WbTranslatePageCapability = AiCapability.createImplementation({
+    implementation: WbTranslatePageCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/feature.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { WbTranslatePageDecorator } from "./WbTranslatePageDecorator.js";
 import { LexicalParser } from "./LexicalParser.js";
+import { WbTranslatePageCapability } from "./capability.js";
 
 export const WbTranslatePageFeature = createFeature({
     name: "AiPowerUps/WbTranslatePage",
     register(container) {
+        container.register(WbTranslatePageCapability);
         container.register(LexicalParser).inSingletonScope();
         container.registerDecorator(WbTranslatePageDecorator);
     }

--- a/packages/ai-powerups/src/api/features/shared/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/shared/abstractions.ts
@@ -4,7 +4,12 @@ import type { ZodType } from "zod";
 export interface IAiPowerUpsSettingsGroupHandler {
     readonly name: string;
     readonly inputSchema: ZodType<unknown>;
-    mapFromStorage(persisted: unknown): unknown;
+    /**
+     * `all` is the entire persisted settings blob. A group only needs it to read a section it does
+     * not own, which in practice means migrating away from one: `connections` and `modelRoles` both
+     * derive their defaults from the legacy `providers` section the first time they load.
+     */
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): unknown;
     mapToStorage(internal: unknown, existing: unknown | null): Promise<unknown>;
 }
 

--- a/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
+++ b/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
@@ -5,6 +5,7 @@ import { TaskService } from "@webiny/api-core/features/task/TaskService/index.js
 import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
 import { UpdateSettingsUseCase } from "~/api/features/UpdateSettings/index.js";
+import { AiCapability } from "~/api/features/Capabilities/index.js";
 import { AiPowerUpsSettingsGraphQLMapper } from "./abstractions.js";
 import {
     WB_GENERATE_PAGE_CONTENT_TASK_ID,
@@ -27,8 +28,21 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
                 modelName: String!
             }
 
+            type AiCapability {
+                id: String!
+                label: String!
+                description: String!
+                defaultRole: String!
+                """
+                The capability's own prompt guidance, when it has a fixed block a project can
+                replace. Null means only additional instructions apply.
+                """
+                guidance: String
+            }
+
             type AiPowerUpsQuery {
                 listModels: [AiModel!]!
+                listCapabilities: [AiCapability!]!
                 getSettings: JSON
             }
 
@@ -91,6 +105,26 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
             dependencies: [Ai],
             resolver: (ai: Ai.Interface) => {
                 return async () => ai.listModels();
+            }
+        });
+
+        /*
+         * Read straight off the container's registered capabilities. The admin screen has no list
+         * of its own, so a feature that registers a capability gets a settings row without touching
+         * the admin app.
+         */
+        builder.addResolver({
+            path: "AiPowerUpsQuery.listCapabilities",
+            dependencies: [[AiCapability, { multiple: true }]],
+            resolver: (capabilities: AiCapability.Interface[]) => {
+                return async () =>
+                    capabilities.map(c => ({
+                        id: c.id,
+                        label: c.label,
+                        description: c.description,
+                        defaultRole: c.defaultRole,
+                        guidance: c.guidance ?? null
+                    }));
             }
         });
 

--- a/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
+++ b/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
@@ -33,11 +33,6 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
                 label: String!
                 description: String!
                 defaultRole: String!
-                """
-                The capability's own prompt guidance, when it has a fixed block a project can
-                replace. Null means only additional instructions apply.
-                """
-                guidance: String
             }
 
             type AiPowerUpsQuery {
@@ -122,8 +117,7 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
                         id: c.id,
                         label: c.label,
                         description: c.description,
-                        defaultRole: c.defaultRole,
-                        guidance: c.guidance ?? null
+                        defaultRole: c.defaultRole
                     }));
             }
         });

--- a/packages/ai-powerups/src/api/types.ts
+++ b/packages/ai-powerups/src/api/types.ts
@@ -1,4 +1,7 @@
 import "@webiny/background-tasks/api/features/TaskController/augmentation.js";
+import "~/api/features/Connections/types.js";
+import "~/api/features/ModelRoles/types.js";
+import "~/api/features/Capabilities/types.js";
 import "~/api/features/Providers/types.js";
 import "~/api/features/Projects/types.js";
 

--- a/packages/api-graphql/__tests__/GraphQLSchemaBuilder.test.ts
+++ b/packages/api-graphql/__tests__/GraphQLSchemaBuilder.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { createAbstraction } from "@webiny/feature/api";
+import { GraphQLSchemaBuilder } from "~/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.js";
+
+interface IGreeter {
+    greet(): string;
+}
+
+const Greeter = createAbstraction<IGreeter>("TestGreeter");
+
+class Hello implements IGreeter {
+    greet() {
+        return "hello";
+    }
+}
+
+class Goodbye implements IGreeter {
+    greet() {
+        return "goodbye";
+    }
+}
+
+/**
+ * `addResolver` resolves its dependencies off the request container at call time, so the resolver
+ * has to be invoked through the built resolver map to see what it actually received.
+ */
+function callResolver(builder: GraphQLSchemaBuilder.Interface, path: string, container: Container) {
+    const schema = builder.build();
+    const [type, field] = path.split(".");
+    const resolver = (schema.resolvers as Record<string, Record<string, any>>)[type][field];
+
+    return resolver({}, {}, { container }, {});
+}
+
+describe("GraphQLSchemaBuilder resolver dependencies", () => {
+    it("single-resolves a bare abstraction", async () => {
+        const container = new Container();
+        container.register(
+            Greeter.createImplementation({ implementation: Hello, dependencies: [] })
+        );
+
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greeting: String
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greeting",
+            dependencies: [Greeter],
+            resolver: (greeter: IGreeter) => () => greeter.greet()
+        });
+
+        expect(await callResolver(builder, "Query.greeting", container)).toBe("hello");
+    });
+
+    /*
+     * The regression this file exists for. `addResolver` accepted the `[abstraction, options]`
+     * dependency tuple, destructured it, dropped the options and single-resolved anyway, so a
+     * resolver asking for every implementation got one object and died on `.map`. It surfaced as
+     * "e.map is not a function" from the resolver, with nothing pointing at the builder.
+     */
+    it("resolves every implementation when a dependency asks for multiple", async () => {
+        const container = new Container();
+        container.register(
+            Greeter.createImplementation({ implementation: Hello, dependencies: [] })
+        );
+        container.register(
+            Greeter.createImplementation({ implementation: Goodbye, dependencies: [] })
+        );
+
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greetings: [String]
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greetings",
+            dependencies: [[Greeter, { multiple: true }]],
+            resolver: (greeters: IGreeter[]) => () => greeters.map(g => g.greet())
+        });
+
+        const result = await callResolver(builder, "Query.greetings", container);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toEqual(expect.arrayContaining(["hello", "goodbye"]));
+    });
+
+    it("returns an array, not undefined, when nothing is registered for a multiple dependency", async () => {
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greetings: [String]
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greetings",
+            dependencies: [[Greeter, { multiple: true }]],
+            resolver: (greeters: IGreeter[]) => () => greeters.map(g => g.greet())
+        });
+
+        expect(await callResolver(builder, "Query.greetings", new Container())).toEqual([]);
+    });
+});

--- a/packages/api-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
+++ b/packages/api-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
@@ -20,8 +20,17 @@ export class GraphQLSchemaBuilder implements Abstraction.Interface {
 
         const graphqlResolver = (parent: any, args: TArgs, context: any, info: any) => {
             const resolvedDeps = dependencies.map((dep: Dependency) => {
-                const [abstraction] = Array.isArray(dep) ? dep : [dep];
-                return context.container.resolve(abstraction);
+                /*
+                 * `Dependency` allows `[abstraction, { multiple: true }]`, same as anywhere else in
+                 * the container. This used to destructure the tuple, throw the options away and
+                 * always single-resolve, so a resolver asking for every implementation of an
+                 * abstraction received one object and failed on `.map`.
+                 */
+                const [abstraction, options] = Array.isArray(dep) ? dep : [dep, undefined];
+
+                return options?.multiple
+                    ? context.container.resolveAll(abstraction)
+                    : context.container.resolve(abstraction);
             });
 
             const actualResolver = resolver(...resolvedDeps);


### PR DESCRIPTION
The `next` counterpart of #5693, which is merged into `release/6.5.0`.

AI features each read `providers.presets[0]` and used whatever model happened to be first. This replaces that with three layers:

- **Connections** — a credential for a vendor, carrying no model. The old `providers` section bundled a key with one model, so using two models from the same vendor meant pasting the key twice.
- **Model roles** — `fast`, `standard`, `vision`. A closed set of three named slots a project fills once.
- **Capabilities** — one per AI feature, registered by the feature itself. Empty by default; a project can move a feature to a different role, pin an exact connection and model, or append instructions to its prompt.

`ResolveAiCapabilityUseCase` is the single place that knows the precedence: a pinned connection and model, else the chosen role, else the capability's declared default role, else `standard`. Six use cases previously answered "which model runs this feature" independently and only happened to agree.

Prompt customisation is append-only. Replacing a prompt outright was prototyped and removed: for most capabilities the prompt carries the output contract the surrounding code parses, so replacing it means replacing part of the implementation.

## Upgrade path

A project that already uses AI Power-Ups keeps working without opening the settings screen. `ModelRoles` seeds `standard` from `providers.presets[0]` and `Connections` derives a connection from the same section, carrying the encrypted key across. `fast` and `vision` stay empty and fall back to `standard`, so image work keeps running on the model it ran on before. `__tests__/features/upgradeFromLegacyProviders.test.ts` pins this, including the id agreement between the two handlers that nothing else enforces.

## Difference from #5693

Same work, ported onto `next` with two adaptations:

- `next` refactored image enrichment into `Prepare`/`Apply` use cases with a streaming route. Capability resolution lives in `PrepareImageEnrichmentUseCase` here rather than in the task.
- `handler-graphql` is `api-graphql` on `next`, so the `multiple: true` resolver fix (#5698 on 6.5.0) is included here as its own commit rather than arriving with the forward merge.

## Verified

Manually tested against a deployed API: settings screen renders, saves with untouched fields, API keys survive a save without being re-entered, model lists filter by the selected connection's vendor, and CMS entry generation resolves and reaches the provider end to end.

`yarn build` clean across the workspace, `adio` and lint clean, 57 tests in `ai-powerups` and 45 in `api-graphql`.

## Follow-up

#5720 covers two places that stay silent: image enrichment swallowing a config failure, and the role fallback not being surfaced anywhere.

Workspace: wby-next9 · AI Powerups settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AI connections, model roles, and per-capability overrides for models, connections, and instructions.
  * Added capability discovery in AI Power-Ups settings and through the GraphQL API.
  * AI-powered content generation, translation, revision comparison, and image enrichment now use capability-specific configuration and instructions.
* **Improvements**
  * Existing provider settings migrate to the new connection and role configuration.
  * Generation controls appear only when a usable standard model is configured.
  * Image enrichment provides clearer configuration errors and customized prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->