### PR TITLE
feat(ai-powerups): resolve AI models per capability instead of taking the first provider

### DIFF
--- a/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/CapabilitiesHandler.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import CapabilitiesHandler from "~/api/features/Capabilities/CapabilitiesHandler.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+
+function buildHandler(): AiPowerUpsSettingsGroupHandler.Interface {
+    const container = new Container();
+    container.register(CapabilitiesHandler);
+
+    return container.resolve(AiPowerUpsSettingsGroupHandler);
+}
+
+const handler = buildHandler();
+
+describe("CapabilitiesHandler", () => {
+    /*
+     * The admin form sends `null` for a field nobody has touched, and every field in an override is
+     * untouched by default. The first version of this schema required strings, so saving the
+     * settings screen without configuring a single capability failed with four copies of
+     * "Invalid input: expected string, received null" and no indication of which section was at
+     * fault.
+     */
+    it("accepts the nulls the form sends for untouched fields", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: {
+                "cms.generateEntry": {
+                    roleId: null,
+                    connectionId: null,
+                    model: null,
+                    additionalInstructions: null
+                }
+            }
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts a fully configured override", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: {
+                "cms.generateEntry": {
+                    roleId: "fast",
+                    connectionId: "conn-1",
+                    model: "anthropic/claude-haiku-4-5",
+                    additionalInstructions: "Be brief."
+                }
+            }
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("still rejects a role that does not exist", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: { "cms.generateEntry": { roleId: "cheapest" } }
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    it("drops an override where every field is empty", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "cms.generateEntry": {
+                        roleId: null,
+                        connectionId: null,
+                        additionalInstructions: "   "
+                    },
+                    "wb.generatePage": { additionalInstructions: "Keep it short." }
+                }
+            },
+            null
+        );
+
+        expect(Object.keys((stored as any).overrides)).toEqual(["wb.generatePage"]);
+    });
+
+    it("keeps nulls and empty strings out of a stored override", async () => {
+        const stored = await handler.mapToStorage(
+            {
+                overrides: {
+                    "wb.generatePage": {
+                        roleId: null,
+                        connectionId: "",
+                        model: null,
+                        additionalInstructions: "Keep it short."
+                    }
+                }
+            },
+            null
+        );
+
+        expect((stored as any).overrides["wb.generatePage"]).toEqual({
+            additionalInstructions: "Keep it short."
+        });
+    });
+
+    /*
+     * There is no prompt field here any more. Replacing a capability's prompt was offered and then
+     * removed: for most capabilities the prompt carries the output contract the surrounding code
+     * parses, so it is implementation rather than settings. `additionalInstructions` is the whole
+     * of prompt customisation now.
+     */
+    it("rejects a prompt override, which is no longer a thing", () => {
+        const result = handler.inputSchema.safeParse({
+            overrides: { "cms.compareEntryRevisions": { guidance: "Mine now." } }
+        });
+
+        // Zod strips the unknown key rather than failing, so the check is that it never lands.
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ overrides: { "cms.compareEntryRevisions": {} } });
+    });
+
+    it("round-trips an absent section to an empty override map", () => {
+        expect(handler.mapFromStorage(undefined)).toEqual({ overrides: {} });
+    });
+});

--- a/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
+++ b/packages/ai-powerups/__tests__/features/Capabilities/ResolveAiCapabilityUseCase.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { Result } from "@webiny/feature/api";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import { AiCapability } from "~/api/features/Capabilities/abstractions.js";
+import { ResolveAiCapabilityUseCase } from "~/api/features/Capabilities/abstractions.js";
+import { ResolveAiCapabilityUseCaseImplementation } from "~/api/features/Capabilities/ResolveAiCapabilityUseCase.js";
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+type Overrides = IAiPowerUpsSettings["capabilities"]["overrides"];
+type Roles = IAiPowerUpsSettings["modelRoles"]["roles"];
+
+const CHEAP = "anthropic/claude-haiku-4-5";
+const MAIN = "anthropic/claude-sonnet-4-5";
+
+const roles = (partial: Partial<Roles> = {}): Roles => ({
+    fast: { connectionId: "", model: "" },
+    standard: { connectionId: "conn-1", model: MAIN },
+    vision: { connectionId: "", model: "" },
+    ...partial
+});
+
+function settings(params: {
+    roles?: Partial<Roles>;
+    overrides?: Overrides;
+    connections?: IAiPowerUpsSettings["connections"]["presets"];
+}): IAiPowerUpsSettings {
+    return {
+        connections: {
+            presets: params.connections ?? [
+                {
+                    id: "conn-1",
+                    name: "Anthropic (prod)",
+                    sdkName: "anthropic",
+                    apiKeyMasked: "sk-ant-1…9999",
+                    apiKeyEncrypted: "encrypted-1"
+                }
+            ]
+        },
+        modelRoles: { roles: roles(params.roles) },
+        capabilities: { overrides: params.overrides ?? {} }
+    } as unknown as IAiPowerUpsSettings;
+}
+
+/** `standard` and `fast` differ, so which role answered is visible in the model alone. */
+class TestCapability implements AiCapability.Interface {
+    readonly id = "test.capability";
+    readonly label = "Test capability";
+    readonly description = "For tests.";
+    readonly defaultRole = "standard" as const;
+    readonly guidance = "Webiny guidance.";
+}
+
+class RolelessCapability implements AiCapability.Interface {
+    readonly id = "test.noGuidance";
+    readonly label = "No guidance";
+    readonly description = "Prompt is assembled per request.";
+    readonly defaultRole = "vision" as const;
+}
+
+class StubEncryption implements Encryption.Interface {
+    async encrypt(plain: string) {
+        return `encrypted-${plain}`;
+    }
+    /** Prefixed so a test can tell a decrypted key from the stored ciphertext. */
+    async decrypt(encrypted: string) {
+        return `decrypted:${encrypted}`;
+    }
+}
+
+function resolver(value: IAiPowerUpsSettings) {
+    const container = new Container();
+
+    container.register(
+        AiCapability.createImplementation({ implementation: TestCapability, dependencies: [] })
+    );
+    container.register(
+        AiCapability.createImplementation({ implementation: RolelessCapability, dependencies: [] })
+    );
+    // Closes over `value`, so it has to be built per call rather than hoisted like the others.
+    class StubGetSettings implements GetSettingsUseCase.Interface {
+        async execute() {
+            return Result.ok(value);
+        }
+    }
+
+    container.register(
+        GetSettingsUseCase.createImplementation({
+            implementation: StubGetSettings,
+            dependencies: []
+        })
+    );
+    container.register(
+        Encryption.createImplementation({
+            implementation: StubEncryption,
+            dependencies: []
+        })
+    );
+    container.register(ResolveAiCapabilityUseCaseImplementation);
+
+    return container.resolve(ResolveAiCapabilityUseCase);
+}
+
+describe("ResolveAiCapabilityUseCase", () => {
+    it("uses the capability's default role", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.isOk()).toBe(true);
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+        expect(result.value.connection).toEqual({
+            sdkName: "anthropic",
+            apiKey: "decrypted:encrypted-1"
+        });
+    });
+
+    it("decrypts the key rather than handing back what is stored", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.value.connection.apiKey).not.toBe("encrypted-1");
+    });
+
+    it("honours a role chosen for the capability", async () => {
+        const result = await resolver(
+            settings({
+                roles: { fast: { connectionId: "conn-1", model: CHEAP } },
+                overrides: { "test.capability": { roleId: "fast" } }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(CHEAP);
+        expect(result.value.roleId).toBe("fast");
+    });
+
+    it("lets a pinned connection and model beat the role", async () => {
+        const result = await resolver(
+            settings({
+                overrides: {
+                    "test.capability": { roleId: "fast", connectionId: "conn-1", model: CHEAP }
+                }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(CHEAP);
+        expect(result.value.roleId).toBeNull();
+    });
+
+    it("ignores a half-finished pin, because guessing the other half is worse", async () => {
+        const result = await resolver(
+            settings({ overrides: { "test.capability": { model: CHEAP } } })
+        ).execute("test.capability");
+
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+    });
+
+    it("falls back to standard when the requested role is empty, and says so", async () => {
+        // Reproduces an upgrade: migration fills only `standard`, so image work keeps running on
+        // the model it ran on before rather than failing.
+        const result = await resolver(settings({})).execute("test.noGuidance");
+
+        expect(result.value.model).toBe(MAIN);
+        expect(result.value.roleId).toBe("standard");
+        expect(result.value.fellBackToStandard).toBe(true);
+    });
+
+    it("fails with a message naming the settings screen when nothing is configured", async () => {
+        const result = await resolver(
+            settings({ roles: { standard: { connectionId: "", model: "" } } })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("Model roles");
+    });
+
+    it("fails when the role names a connection that has been deleted", async () => {
+        const result = await resolver(settings({ connections: [] })).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("no longer exists");
+    });
+
+    it("fails when the connection exists but has no key", async () => {
+        const result = await resolver(
+            settings({
+                connections: [
+                    {
+                        id: "conn-1",
+                        name: "Anthropic (prod)",
+                        sdkName: "anthropic",
+                        apiKeyMasked: "",
+                        apiKeyEncrypted: ""
+                    }
+                ]
+            })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("no API key");
+    });
+
+    it("rejects a model paired with another vendor's credential", async () => {
+        const result = await resolver(
+            settings({ roles: { standard: { connectionId: "conn-1", model: "openai/gpt-5" } } })
+        ).execute("test.capability");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("cannot run on");
+    });
+
+    it("returns the capability's own guidance by default", async () => {
+        const result = await resolver(settings({})).execute("test.capability");
+
+        expect(result.value.guidance).toBe("Webiny guidance.");
+        expect(result.value.additionalInstructions).toBe("");
+    });
+
+    it("ignores a prompt override, because there is no such thing any more", async () => {
+        const result = await resolver(
+            settings({
+                overrides: {
+                    "test.capability": { guidance: "Mine now." } as Overrides[string]
+                }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.guidance).toBe("Webiny guidance.");
+    });
+
+    it("passes additional instructions through, trimmed", async () => {
+        const result = await resolver(
+            settings({
+                overrides: { "test.capability": { additionalInstructions: "  Be brief.  " } }
+            })
+        ).execute("test.capability");
+
+        expect(result.value.additionalInstructions).toBe("Be brief.");
+    });
+
+    it("fails loudly on an unregistered capability id", async () => {
+        const result = await resolver(settings({})).execute("nope.notRegistered");
+
+        expect(result.isFail()).toBe(true);
+        expect(result.error.message).toContain("Unknown AI capability");
+    });
+});

--- a/packages/ai-powerups/__tests__/features/Connections/ConnectionsHandler.test.ts
+++ b/packages/ai-powerups/__tests__/features/Connections/ConnectionsHandler.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { Masker } from "@webiny/api-core/features/masker/index.js";
+import ConnectionsHandler from "~/api/features/Connections/ConnectionsHandler.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import type { ConnectionsSettings } from "~/api/features/Connections/types.js";
+
+class StubEncryption implements Encryption.Interface {
+    async encrypt(plain: string) {
+        return `enc(${plain})`;
+    }
+    async decrypt(encrypted: string) {
+        return encrypted.replace(/^enc\((.*)\)$/, "$1");
+    }
+}
+
+class StubMasker implements Masker.Interface {
+    mask(value: string) {
+        return `${value.slice(0, 4)}…${value.slice(-2)}`;
+    }
+}
+
+function handler(): AiPowerUpsSettingsGroupHandler.Interface {
+    const container = new Container();
+    container.register(
+        Encryption.createImplementation({ implementation: StubEncryption, dependencies: [] })
+    );
+    container.register(
+        Masker.createImplementation({ implementation: StubMasker, dependencies: [] })
+    );
+    container.register(ConnectionsHandler);
+
+    return container.resolve(AiPowerUpsSettingsGroupHandler);
+}
+
+/** A settings blob from before this section existed. */
+const legacyRaw = {
+    providers: {
+        presets: [
+            {
+                id: "prov-1",
+                name: "Anthropic",
+                model: "anthropic/claude-sonnet-4-5",
+                apiKeyEncrypted: "enc(sk-ant-real)",
+                apiKeyMasked: "sk-a…al"
+            }
+        ]
+    }
+};
+
+describe("ConnectionsHandler", () => {
+    it("derives connections from the legacy providers section", () => {
+        const result = handler().mapFromStorage(undefined, legacyRaw) as ConnectionsSettings;
+
+        expect(result.presets).toEqual([
+            {
+                id: "prov-1",
+                name: "Anthropic",
+                sdkName: "anthropic",
+                apiKeyMasked: "sk-a…al",
+                apiKeyEncrypted: "enc(sk-ant-real)"
+            }
+        ]);
+    });
+
+    it("ignores the legacy section once connections exist", () => {
+        const result = handler().mapFromStorage(
+            { presets: [{ id: "c1", name: "Mine", sdkName: "openai", apiKeyEncrypted: "enc(k)" }] },
+            legacyRaw
+        ) as ConnectionsSettings;
+
+        expect(result.presets).toHaveLength(1);
+        expect(result.presets[0].id).toBe("c1");
+    });
+
+    /*
+     * The bug this test exists for. The form only ever sees a mask, so an unchanged key comes back
+     * as the mask and `mapToStorage` has to recognise it and carry the ciphertext forward. On the
+     * first save after an upgrade the "existing" value is itself derived from `providers`, and
+     * `UpdateSettingsRepository` was calling `mapFromStorage` without the full blob. It compared
+     * against an empty list, matched nothing, and wrote an empty key: the project's real API key,
+     * silently gone on the first save.
+     */
+    it("carries a masked key forward instead of blanking it", async () => {
+        const h = handler();
+        const existing = h.mapFromStorage(undefined, legacyRaw);
+
+        const stored = (await h.mapToStorage(
+            {
+                presets: [
+                    { id: "prov-1", name: "Anthropic", sdkName: "anthropic", apiKey: "sk-a…al" }
+                ]
+            },
+            existing
+        )) as { presets: Array<{ apiKeyEncrypted: string }> };
+
+        expect(stored.presets[0].apiKeyEncrypted).toBe("enc(sk-ant-real)");
+    });
+
+    it("encrypts and masks a newly entered key", async () => {
+        const stored = (await handler().mapToStorage(
+            {
+                presets: [{ id: "c1", name: "New", sdkName: "openai", apiKey: "sk-brand-new-key" }]
+            },
+            null
+        )) as { presets: Array<{ apiKeyEncrypted: string; apiKeyMasked: string }> };
+
+        expect(stored.presets[0].apiKeyEncrypted).toBe("enc(sk-brand-new-key)");
+        expect(stored.presets[0].apiKeyMasked).not.toContain("brand");
+    });
+
+    it("accepts a null apiKey from the form", () => {
+        const result = handler().inputSchema.safeParse({
+            presets: [{ id: "c1", name: "New", sdkName: "openai", apiKey: null }]
+        });
+
+        expect(result.success).toBe(true);
+    });
+});

--- a/packages/ai-powerups/package.json
+++ b/packages/ai-powerups/package.json
@@ -30,6 +30,7 @@
     "@webiny/app-website-builder": "0.0.0",
     "@webiny/app-websockets": "0.0.0",
     "@webiny/background-tasks": "0.0.0",
+    "@webiny/di": "^1.0.2",
     "@webiny/feature": "0.0.0",
     "@webiny/icons": "0.0.0",
     "@webiny/languages": "0.0.0",

--- a/packages/ai-powerups/src/admin/features/feature.ts
+++ b/packages/ai-powerups/src/admin/features/feature.ts
@@ -1,5 +1,6 @@
 import { createFeature } from "@webiny/feature/admin";
 import { ListModelsFeature } from "~/admin/features/listModels/index.js";
+import { ListCapabilitiesFeature } from "~/admin/features/listCapabilities/index.js";
 import { SharedSettingsFeature } from "~/admin/features/settings/shared/index.js";
 import { GetSettingsFeature } from "~/admin/features/settings/getSettings/index.js";
 import { UpdateSettingsFeature } from "~/admin/features/settings/updateSettings/index.js";
@@ -13,6 +14,7 @@ export const AiPowerUpsHeadlessFeatures = createFeature({
         GetSettingsFeature.register(container);
         UpdateSettingsFeature.register(container);
         ListModelsFeature.register(container);
+        ListCapabilitiesFeature.register(container);
         GeneratePageContentFeature.register(container);
         CompareEntryRevisionsFeature.register(container);
     },

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesGateway.ts
@@ -1,0 +1,39 @@
+import { MainGraphQLClient } from "@webiny/app/exports/admin.js";
+import { ListCapabilitiesGateway as GatewayAbstraction } from "./abstractions.js";
+import type { AiCapability } from "./abstractions.js";
+
+const LIST_CAPABILITIES = /* GraphQL */ `
+    query ListAiCapabilities {
+        aiPowerUps {
+            listCapabilities {
+                id
+                label
+                description
+                defaultRole
+            }
+        }
+    }
+`;
+
+type ListCapabilitiesResponse = {
+    aiPowerUps: {
+        listCapabilities: AiCapability[];
+    };
+};
+
+class ListCapabilitiesGatewayImpl implements GatewayAbstraction.Interface {
+    constructor(private client: MainGraphQLClient.Interface) {}
+
+    async execute(): Promise<AiCapability[]> {
+        const response = await this.client.execute<ListCapabilitiesResponse>({
+            query: LIST_CAPABILITIES
+        });
+
+        return response.aiPowerUps.listCapabilities ?? [];
+    }
+}
+
+export const ListCapabilitiesGateway = GatewayAbstraction.createImplementation({
+    implementation: ListCapabilitiesGatewayImpl,
+    dependencies: [MainGraphQLClient]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesRepository.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesRepository.ts
@@ -1,0 +1,30 @@
+import { makeAutoObservable, runInAction } from "mobx";
+import {
+    ListCapabilitiesRepository as RepoAbstraction,
+    ListCapabilitiesGateway
+} from "./abstractions.js";
+import type { AiCapability } from "./abstractions.js";
+
+class ListCapabilitiesRepositoryImpl implements RepoAbstraction.Interface {
+    private capabilities: AiCapability[] = [];
+
+    constructor(private gateway: ListCapabilitiesGateway.Interface) {
+        makeAutoObservable(this);
+    }
+
+    async execute(): Promise<void> {
+        const capabilities = await this.gateway.execute();
+        runInAction(() => {
+            this.capabilities = capabilities;
+        });
+    }
+
+    getCapabilities(): AiCapability[] {
+        return this.capabilities;
+    }
+}
+
+export const ListCapabilitiesRepository = RepoAbstraction.createImplementation({
+    implementation: ListCapabilitiesRepositoryImpl,
+    dependencies: [ListCapabilitiesGateway]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesUseCase.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/ListCapabilitiesUseCase.ts
@@ -1,0 +1,17 @@
+import {
+    ListCapabilitiesUseCase as UseCaseAbstraction,
+    ListCapabilitiesRepository
+} from "./abstractions.js";
+
+class ListCapabilitiesUseCaseImpl implements UseCaseAbstraction.Interface {
+    constructor(private repository: ListCapabilitiesRepository.Interface) {}
+
+    async execute(): Promise<void> {
+        return this.repository.execute();
+    }
+}
+
+export const ListCapabilitiesUseCase = UseCaseAbstraction.createImplementation({
+    implementation: ListCapabilitiesUseCaseImpl,
+    dependencies: [ListCapabilitiesRepository]
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/abstractions.ts
@@ -1,0 +1,42 @@
+import { createAbstraction } from "@webiny/feature/admin";
+
+export interface AiCapability {
+    id: string;
+    label: string;
+    description: string;
+    defaultRole: string;
+}
+
+export interface IListCapabilitiesGateway {
+    execute(): Promise<AiCapability[]>;
+}
+
+export const ListCapabilitiesGateway = createAbstraction<IListCapabilitiesGateway>(
+    "AiPowerUps/ListCapabilitiesGateway"
+);
+export namespace ListCapabilitiesGateway {
+    export type Interface = IListCapabilitiesGateway;
+}
+
+export interface IListCapabilitiesRepository {
+    execute(): Promise<void>;
+    getCapabilities(): AiCapability[];
+}
+
+export const ListCapabilitiesRepository = createAbstraction<IListCapabilitiesRepository>(
+    "AiPowerUps/ListCapabilitiesRepository"
+);
+export namespace ListCapabilitiesRepository {
+    export type Interface = IListCapabilitiesRepository;
+}
+
+export interface IListCapabilitiesUseCase {
+    execute(): Promise<void>;
+}
+
+export const ListCapabilitiesUseCase = createAbstraction<IListCapabilitiesUseCase>(
+    "AiPowerUps/ListCapabilitiesUseCase"
+);
+export namespace ListCapabilitiesUseCase {
+    export type Interface = IListCapabilitiesUseCase;
+}

--- a/packages/ai-powerups/src/admin/features/listCapabilities/feature.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/feature.ts
@@ -1,0 +1,19 @@
+import { createFeature } from "@webiny/feature/admin";
+import { ListCapabilitiesUseCase as UseCaseAbstraction } from "./abstractions.js";
+import { ListCapabilitiesUseCase } from "./ListCapabilitiesUseCase.js";
+import { ListCapabilitiesRepository } from "./ListCapabilitiesRepository.js";
+import { ListCapabilitiesGateway } from "./ListCapabilitiesGateway.js";
+
+export const ListCapabilitiesFeature = createFeature({
+    name: "AiPowerUps/ListCapabilities",
+    register(container) {
+        container.register(ListCapabilitiesUseCase);
+        container.register(ListCapabilitiesRepository).inSingletonScope();
+        container.register(ListCapabilitiesGateway).inSingletonScope();
+    },
+    resolve(container) {
+        return {
+            useCase: container.resolve(UseCaseAbstraction)
+        };
+    }
+});

--- a/packages/ai-powerups/src/admin/features/listCapabilities/index.ts
+++ b/packages/ai-powerups/src/admin/features/listCapabilities/index.ts
@@ -1,0 +1,7 @@
+export { ListCapabilitiesFeature } from "./feature.js";
+export {
+    ListCapabilitiesUseCase,
+    ListCapabilitiesRepository,
+    ListCapabilitiesGateway
+} from "./abstractions.js";
+export type { AiCapability } from "./abstractions.js";

--- a/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
+++ b/packages/ai-powerups/src/admin/features/settings/shared/abstractions.ts
@@ -19,14 +19,27 @@ export interface IAiPowerUpsPersonaPreset {
     style?: string;
 }
 
+export interface IAiPowerUpsCapabilityOverride {
+    roleId?: string;
+    connectionId?: string;
+    model?: string;
+    additionalInstructions?: string;
+}
+
 export interface IAiPowerUpsSettings {
-    providers: {
+    connections: {
         presets: {
+            id: string;
             name: string;
-            description: string;
-            model: string;
+            sdkName: string;
             apiKey: string;
         }[];
+    };
+    modelRoles: {
+        roles: Record<string, { connectionId: string; model: string }>;
+    };
+    capabilities: {
+        overrides: Record<string, IAiPowerUpsCapabilityOverride>;
     };
     readerPersonas: {
         presets: IAiPowerUpsPersonaPreset[];

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/AiPowerUpsSettingsPresenter.ts
@@ -49,8 +49,34 @@ class AiPowerUpsSettingsPresenterImpl implements PresenterAbstraction.Interface 
         this.errors = [];
 
         try {
-            const data = await this.getSettings.execute();
+            /*
+             * Groups that build fields from server data get to load it first, in parallel with the
+             * settings themselves.
+             *
+             * `allSettled`, not `all`: a group whose init fails must not take the screen down with
+             * it. One broken query used to leave the page with a heading, a Save button and no tabs
+             * at all, which hid the working sections and the personas someone came here to edit.
+             * Now the failure is reported and every other tab still renders.
+             */
+            const [data, initResults] = await Promise.all([
+                this.getSettings.execute(),
+                Promise.allSettled(this.groups.map(group => group.init?.()))
+            ]);
+
+            const initErrors = initResults.flatMap((result, index) => {
+                if (result.status !== "rejected") {
+                    return [];
+                }
+
+                const label = this.groups[index].label;
+                const reason =
+                    result.reason instanceof Error ? result.reason.message : String(result.reason);
+
+                return [`Could not load the "${label}" section: ${reason}`];
+            });
+
             runInAction(() => {
+                this.errors = initErrors;
                 this.form = this.buildForm();
                 this.form.setData(data);
             });

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/feature.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/feature.ts
@@ -1,7 +1,9 @@
 import { createFeature } from "@webiny/feature/admin";
 import { AiPowerUpsSettingsPresenter as PresenterAbstraction } from "./abstractions.js";
 import { AiPowerUpsSettingsPresenter } from "./AiPowerUpsSettingsPresenter.js";
-import { ProviderSettings } from "../ProvidersSettings.js";
+import { ConnectionsSettings } from "../ConnectionsSettings.js";
+import { ModelRolesSettings } from "../ModelRolesSettings.js";
+import { CapabilitiesSettings } from "../CapabilitiesSettings.js";
 import { ReaderPersonasSettings } from "../ReaderPersonasSettings.js";
 import { WriterPersonasSettings } from "../WriterPersonasSettings.js";
 import { ProjectsSettings } from "../ProjectsSettings.js";
@@ -9,7 +11,16 @@ import { ProjectsSettings } from "../ProjectsSettings.js";
 export const AiPowerUpsSettingsFeature = createFeature({
     name: "AiPowerUps/Settings/Presenter",
     register(container) {
-        container.register(ProviderSettings);
+        /*
+         * Registration order is tab order. Configuration first (a key, then what each role runs,
+         * then per-feature exceptions), then the prompt content: personas and projects.
+         *
+         * `ProvidersSettings` is gone from the UI. Its stored section still round-trips on the api
+         * so `Connections` and `ModelRoles` can seed themselves from it once.
+         */
+        container.register(ConnectionsSettings);
+        container.register(ModelRolesSettings);
+        container.register(CapabilitiesSettings);
         container.register(ReaderPersonasSettings);
         container.register(WriterPersonasSettings);
         container.register(ProjectsSettings);

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/hasUsableModel.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/hasUsableModel.ts
@@ -1,0 +1,24 @@
+import type { IAiPowerUpsSettings } from "~/admin/features/settings/shared/abstractions.js";
+
+/**
+ * Whether a feature that runs on the Standard role has something to run on.
+ *
+ * The AI entry points hide themselves when the project has no model configured, and they used to
+ * test `providers.presets.length > 0` for it. That test passed for a row with no key in it, so the
+ * button appeared and the request failed. This one checks the whole chain the api will walk: the
+ * role is filled, the connection it names still exists, and that connection has a key.
+ *
+ * Admin only ever sees the masked key, and the mask is non-empty exactly when a key is stored, so
+ * it answers the question without the plaintext leaving the api.
+ */
+export const hasUsableModel = (settings: IAiPowerUpsSettings | null): boolean => {
+    const standard = settings?.modelRoles?.roles?.["standard"];
+
+    if (!standard?.model || !standard.connectionId) {
+        return false;
+    }
+
+    const connection = settings?.connections?.presets?.find(c => c.id === standard.connectionId);
+
+    return Boolean(connection?.apiKey);
+};

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/index.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/index.ts
@@ -1,3 +1,4 @@
 export { AiPowerUpsSettingsFeature } from "./feature.js";
 export { useAiPowerUpsSettings } from "./useAiPowerUpsSettings.js";
+export { hasUsableModel } from "./hasUsableModel.js";
 export { AiPowerUpsSettingsGroup } from "./settingsGroup.js";

--- a/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/settingsGroup.ts
+++ b/packages/ai-powerups/src/admin/presentation/AiPowerUpsSettings/settingsGroup.ts
@@ -15,6 +15,12 @@ export interface IAiPowerUpsSettingsGroup {
     label: string;
     description?: string;
     icon?: Icon;
+    /**
+     * Awaited before `buildForm` runs. Field *options* are evaluated lazily on render, but field
+     * *structure* is not: the Capabilities group builds one field per capability registered on the
+     * api, so that list has to be in hand before the form is built or the tab comes up empty.
+     */
+    init?(): Promise<void>;
     buildForm(formBuilder: IAiPowerUpsSettingsGroupFormBuilder): void;
 }
 

--- a/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/CapabilitiesSettings.ts
@@ -1,0 +1,195 @@
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListCapabilitiesUseCase,
+    ListCapabilitiesRepository
+} from "~/admin/features/listCapabilities/abstractions.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+import { AI_MODEL_ROLE_DISPLAY, roleLabel } from "./modelRoles.js";
+import type { AiCapability } from "~/admin/features/listCapabilities/abstractions.js";
+import type { FormModel, FormModelFactory } from "@webiny/app-admin";
+
+interface ConnectionRow {
+    id: string;
+    name: string;
+    sdkName: string;
+}
+
+/**
+ * One row per AI feature, all of them empty by default.
+ *
+ * The rows come from the api's registered capabilities, so a feature that declares one appears here
+ * without a change to this file. That is the point: the previous plan was a hand-maintained tab per
+ * feature, which is the kind of list that stops matching reality on the second addition.
+ */
+class CapabilitiesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "capabilities";
+    label = "Capabilities";
+    description = "Per-feature model and prompt overrides. Empty means inherit.";
+
+    constructor(
+        private listCapabilities: ListCapabilitiesUseCase.Interface,
+        private capabilitiesRepository: ListCapabilitiesRepository.Interface,
+        private listModels: ListModelsUseCase.Interface,
+        private modelsRepository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await Promise.all([this.listCapabilities.execute(), this.listModels.execute()]);
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            overrides: fields
+                .object()
+                .label("Capabilities")
+                .renderer("passthrough")
+                .fields(f =>
+                    Object.fromEntries(
+                        this.capabilitiesRepository
+                            .getCapabilities()
+                            .map(capability => [
+                                capability.id,
+                                this.buildCapabilityField(f, capability)
+                            ])
+                    )
+                )
+        }));
+
+        form.layout(layout => [layout.row("overrides")]);
+    }
+
+    private buildCapabilityField(
+        f: FormModelFactory.FieldBuilderRegistry,
+        capability: AiCapability
+    ): FormModelFactory.FieldBuilder {
+        const defaultRoleLabel = roleLabel(capability.defaultRole);
+
+        return (
+            f
+                .object()
+                .label(capability.label)
+                /*
+                 * Callbacks, not strings: a string is read as a field name, not as literal text. The
+                 * title happened to survive that because the renderer falls back to the field label,
+                 * but the description silently vanished.
+                 */
+                .renderer("objectAccordionSingle", {
+                    itemTitle: () => capability.label,
+                    itemDescription: () => capability.description,
+                    // Closed by default. Every row is empty until someone changes something, so an
+                    // expanded list of five would be five screens of nothing.
+                    open: false
+                })
+                .fields(cf => ({
+                    /*
+                     * The inherited role goes in the description, not in the option list. An option
+                     * with an empty value is dropped by the select renderer, so the "Inherit (Fast)"
+                     * entry never rendered and nothing said which role this feature falls back to.
+                     * Clearing the field is done with the select's own reset control.
+                     */
+                    roleId: cf
+                        .text()
+                        .label("Model role")
+                        .description(
+                            `Which role supplies this feature's model. Left empty, it uses ${defaultRoleLabel}.`
+                        )
+                        .options(() =>
+                            AI_MODEL_ROLE_DISPLAY.map(role => ({
+                                label: role.label,
+                                value: role.id
+                            }))
+                        ),
+
+                    /*
+                     * Pinning a model bypasses roles for this one feature. It is the escape hatch, not
+                     * the mechanism: a project that pins everything has thrown away the indirection
+                     * that makes "switch our cheap model" a single edit.
+                     */
+                    connectionId: cf
+                        .text()
+                        .label("Pin a connection")
+                        .description("Advanced. Overrides the role above for this feature only.")
+                        .options(({ form }) => [
+                            { label: "Use the role's connection", value: "" },
+                            ...this.getConnections(form).map(c => ({ label: c.name, value: c.id }))
+                        ]),
+                    model: cf
+                        .text()
+                        .label("Pin a model")
+                        .disabledWhen(({ form }) => !this.getPinnedConnection(form, capability.id))
+                        .description(
+                            "Both the connection and the model must be set for a pin to apply."
+                        )
+                        .options(({ form }) => this.getModelOptions(form, capability.id)),
+
+                    additionalInstructions: cf
+                        .text()
+                        .label("Additional instructions")
+                        .renderer("textarea", { rows: 5 })
+                        .description(
+                            "Appended to this feature's prompt. Use this for house style and standing rules."
+                        )
+                        .note(
+                            "Appending keeps Webiny's prompt in place, including the output format the feature depends on."
+                        )
+                }))
+        );
+    }
+
+    private getConnections(form: FormModel.Interface): ConnectionRow[] {
+        const data = form.getData() as { connections?: { presets?: ConnectionRow[] } };
+        return (data.connections?.presets ?? []).filter(c => c.id && c.name);
+    }
+
+    private getOverride(
+        form: FormModel.Interface,
+        capabilityId: string
+    ): { connectionId?: string } {
+        const data = form.getData() as {
+            capabilities?: { overrides?: Record<string, { connectionId?: string }> };
+        };
+        return data.capabilities?.overrides?.[capabilityId] ?? {};
+    }
+
+    private getPinnedConnection(
+        form: FormModel.Interface,
+        capabilityId: string
+    ): ConnectionRow | undefined {
+        const connectionId = this.getOverride(form, capabilityId).connectionId;
+
+        if (!connectionId) {
+            return undefined;
+        }
+
+        return this.getConnections(form).find(c => c.id === connectionId);
+    }
+
+    private getModelOptions(form: FormModel.Interface, capabilityId: string) {
+        const connection = this.getPinnedConnection(form, capabilityId);
+
+        if (!connection) {
+            return [];
+        }
+
+        return this.modelsRepository
+            .getModels()
+            .filter(model => model.providerId === connection.sdkName)
+            .map(model => ({
+                label: model.modelName,
+                value: `${model.providerId}/${model.modelId}`
+            }));
+    }
+}
+
+export const CapabilitiesSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: CapabilitiesSettingsImpl,
+    dependencies: [
+        ListCapabilitiesUseCase,
+        ListCapabilitiesRepository,
+        ListModelsUseCase,
+        ListModelsRepository
+    ]
+});

--- a/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/CmsGenerateContentButton.tsx
+++ b/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/CmsGenerateContentButton.tsx
@@ -5,7 +5,10 @@ import { ReactComponent as ChatIcon } from "@webiny/icons/auto_fix_high.svg";
 import { useOpenDialog } from "@webiny/app-admin";
 import { useModel } from "@webiny/app-headless-cms/admin/components/ModelProvider/useModel.js";
 import { CMS_GENERATE_CONTENT_DIALOG } from "./CmsGenerateContentDialog.js";
-import { useAiPowerUpsSettings } from "~/admin/presentation/AiPowerUpsSettings/index.js";
+import {
+    hasUsableModel,
+    useAiPowerUpsSettings
+} from "~/admin/presentation/AiPowerUpsSettings/index.js";
 import { useContentEntryFormPresenter } from "@webiny/app-headless-cms/exports/admin/cms/entry/editor.js";
 
 export const CmsGenerateContentButton = observer(() => {
@@ -18,7 +21,7 @@ export const CmsGenerateContentButton = observer(() => {
         return null;
     }
 
-    if (!settings || settings.providers.presets.length === 0) {
+    if (!hasUsableModel(settings)) {
         return null;
     }
 

--- a/packages/ai-powerups/src/admin/presentation/ConnectionsSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/ConnectionsSettings.ts
@@ -1,0 +1,87 @@
+import { generateAlphaNumericId } from "@webiny/utils";
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+
+/**
+ * One row per API key. The model select moved to Model roles, so adding a second Anthropic model no
+ * longer means pasting the same key twice.
+ */
+class ConnectionsSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "connections";
+    label = "Connections";
+    description = "API keys for the AI vendors this project uses.";
+
+    constructor(
+        private useCase: ListModelsUseCase.Interface,
+        private repository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await this.useCase.execute();
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            presets: fields
+                .object()
+                .label("Connections")
+                .renderer("objectAccordionMultiple", {
+                    container: false,
+                    addItemLabel: "Add connection",
+                    itemTitle: (data, index) => String(data.name || `Connection #${index + 1}`)
+                })
+                .fields(f => ({
+                    id: f
+                        .text()
+                        .hidden()
+                        .defaultValue(() => generateAlphaNumericId(10)),
+                    name: f
+                        .text()
+                        .label("Name")
+                        .required("Name is required")
+                        .description(
+                            "How this connection appears when picking a model. Name it after the key, not the vendor, so two keys for the same vendor stay distinguishable."
+                        ),
+                    sdkName: f
+                        .text()
+                        .label("Vendor")
+                        .required("Vendor is required")
+                        .description("Which provider this key belongs to.")
+                        .options(() => this.getVendorOptions())
+                        .renderer("select"),
+                    apiKey: f
+                        .text()
+                        .label("API Key")
+                        .required("API Key is required")
+                        .description(
+                            "Encrypted at rest. Only the last few characters are shown after saving."
+                        )
+                }))
+                .list()
+        }));
+
+        form.layout(layout => [layout.row("presets")]);
+    }
+
+    /**
+     * Derived from the registered SDK factories rather than hardcoded, so a project that registers
+     * its own `AiSdkFactory` shows up here without a change to this file.
+     */
+    private getVendorOptions() {
+        const seen = new Map<string, string>();
+
+        for (const model of this.repository.getModels()) {
+            seen.set(model.providerId, model.providerName);
+        }
+
+        return [...seen.entries()].map(([value, label]) => ({ label, value }));
+    }
+}
+
+export const ConnectionsSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: ConnectionsSettingsImpl,
+    dependencies: [ListModelsUseCase, ListModelsRepository]
+});

--- a/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
+++ b/packages/ai-powerups/src/admin/presentation/ModelRolesSettings.ts
@@ -1,0 +1,136 @@
+import { AiPowerUpsSettingsGroup } from "./AiPowerUpsSettings/settingsGroup.js";
+import {
+    ListModelsUseCase,
+    ListModelsRepository
+} from "~/admin/features/listModels/abstractions.js";
+import { AI_MODEL_ROLE_DISPLAY } from "./modelRoles.js";
+import type { FormModel } from "@webiny/app-admin";
+
+interface ConnectionRow {
+    id: string;
+    name: string;
+    sdkName: string;
+}
+
+/**
+ * Three selects, and for most projects this is the whole AI configuration: one connection, one
+ * model per role. Everything else in these settings is opt-in.
+ */
+class ModelRolesSettingsImpl implements AiPowerUpsSettingsGroup.Interface {
+    name = "modelRoles";
+    label = "Model roles";
+    description = "Which model does the cheap work, the main work, and the image work.";
+
+    constructor(
+        private useCase: ListModelsUseCase.Interface,
+        private repository: ListModelsRepository.Interface
+    ) {}
+
+    async init(): Promise<void> {
+        await this.useCase.execute();
+    }
+
+    buildForm(form: AiPowerUpsSettingsGroup.FormBuilder): void {
+        form.fields(fields => ({
+            roles: fields
+                .object()
+                .label("Roles")
+                .renderer("passthrough")
+                .fields(f =>
+                    Object.fromEntries(
+                        AI_MODEL_ROLE_DISPLAY.map(role => [
+                            role.id,
+                            f
+                                .object()
+                                .label(role.label)
+                                /*
+                                 * Both callbacks, not strings. A string here is a *field name* to
+                                 * read the value from, not literal text, so passing prose made the
+                                 * renderer look for a child field called "Cheap, low-latency
+                                 * work..." and render no description at all.
+                                 */
+                                .renderer("objectAccordionSingle", {
+                                    itemTitle: () => role.label,
+                                    itemDescription: () => role.description,
+                                    open: true
+                                })
+                                .fields(rf => ({
+                                    connectionId: rf
+                                        .text()
+                                        .label("Connection")
+                                        .description("Which API key runs this role.")
+                                        .options(({ form }) => this.getConnectionOptions(form)),
+                                    model: rf
+                                        .text()
+                                        .label("Model")
+                                        .description(
+                                            "Only models from the selected connection's vendor are listed."
+                                        )
+                                        .disabledWhen(
+                                            ({ form }) => !this.getSelectedConnection(form, role.id)
+                                        )
+                                        .options(({ form }) => this.getModelOptions(form, role.id))
+                                }))
+                        ])
+                    )
+                )
+        }));
+
+        form.layout(layout => [layout.row("roles")]);
+    }
+
+    private getConnections(form: FormModel.Interface): ConnectionRow[] {
+        const data = form.getData() as {
+            connections?: { presets?: ConnectionRow[] };
+        };
+        return data.connections?.presets ?? [];
+    }
+
+    private getConnectionOptions(form: FormModel.Interface) {
+        return this.getConnections(form)
+            .filter(c => c.id && c.name)
+            .map(c => ({ label: c.name, value: c.id }));
+    }
+
+    private getSelectedConnection(
+        form: FormModel.Interface,
+        roleId: string
+    ): ConnectionRow | undefined {
+        const data = form.getData() as {
+            modelRoles?: { roles?: Record<string, { connectionId?: string }> };
+        };
+        const connectionId = data.modelRoles?.roles?.[roleId]?.connectionId;
+
+        if (!connectionId) {
+            return undefined;
+        }
+
+        return this.getConnections(form).find(c => c.id === connectionId);
+    }
+
+    /**
+     * Filtered by the chosen connection's vendor. Listing every model regardless would let someone
+     * pair an OpenAI model with an Anthropic key, which then fails at request time with a provider
+     * auth error that says nothing about the real mistake.
+     */
+    private getModelOptions(form: FormModel.Interface, roleId: string) {
+        const connection = this.getSelectedConnection(form, roleId);
+
+        if (!connection) {
+            return [];
+        }
+
+        return this.repository
+            .getModels()
+            .filter(model => model.providerId === connection.sdkName)
+            .map(model => ({
+                label: model.modelName,
+                value: `${model.providerId}/${model.modelId}`
+            }));
+    }
+}
+
+export const ModelRolesSettings = AiPowerUpsSettingsGroup.createImplementation({
+    implementation: ModelRolesSettingsImpl,
+    dependencies: [ListModelsUseCase, ListModelsRepository]
+});

--- a/packages/ai-powerups/src/admin/presentation/WbContentGeneration/GenerateContentButton.tsx
+++ b/packages/ai-powerups/src/admin/presentation/WbContentGeneration/GenerateContentButton.tsx
@@ -3,13 +3,16 @@ import { IconButton } from "@webiny/admin-ui";
 import { ReactComponent as ChatIcon } from "@webiny/icons/auto_fix_high.svg";
 import { useOpenDialog } from "@webiny/app-admin";
 import { GENERATE_CONTENT_DIALOG } from "./GenerateContentDialog.js";
-import { useAiPowerUpsSettings } from "~/admin/presentation/AiPowerUpsSettings/index.js";
+import {
+    hasUsableModel,
+    useAiPowerUpsSettings
+} from "~/admin/presentation/AiPowerUpsSettings/index.js";
 
 export const GenerateContentButton = () => {
     const { openDialog } = useOpenDialog();
     const { settings } = useAiPowerUpsSettings();
 
-    if (!settings || settings.providers.presets.length === 0) {
+    if (!hasUsableModel(settings)) {
         return null;
     }
 

--- a/packages/ai-powerups/src/admin/presentation/modelRoles.ts
+++ b/packages/ai-powerups/src/admin/presentation/modelRoles.ts
@@ -1,0 +1,38 @@
+/**
+ * The model roles, as the settings screen presents them.
+ *
+ * The api owns the ids and the resolution rules (`~/api/features/ModelRoles/roles.ts`); this owns
+ * the words. The ids are repeated rather than imported because admin and api are separate bundles
+ * and nothing else in `src/admin` reaches across that line. Settings section names are already
+ * duplicated the same way.
+ *
+ * The set is closed by design, so a constant is safe: an extension can add a capability, never a
+ * role.
+ */
+export const AI_MODEL_ROLE_IDS = ["fast", "standard", "vision"] as const;
+
+export type AiModelRoleId = (typeof AI_MODEL_ROLE_IDS)[number];
+
+/** Typed as a full record, so adding a role id without a label is a compile error. */
+const ROLE_TEXT: Record<AiModelRoleId, { label: string; description: string }> = {
+    fast: {
+        label: "Fast",
+        description:
+            "Cheap, low-latency work where a smaller model is good enough: summarising, classifying, comparing."
+    },
+    standard: {
+        label: "Standard",
+        description:
+            "The workhorse. Anything that writes content a person will read, or has to follow a schema and call tools. Every other role falls back to this one when left empty."
+    },
+    vision: {
+        label: "Vision",
+        description:
+            "Work that reads images. Pick a model that accepts image input. Left empty, image features fall back to Standard and only work there if Standard is multimodal too."
+    }
+};
+
+export const AI_MODEL_ROLE_DISPLAY = AI_MODEL_ROLE_IDS.map(id => ({ id, ...ROLE_TEXT[id] }));
+
+export const roleLabel = (id: string): string =>
+    id in ROLE_TEXT ? ROLE_TEXT[id as AiModelRoleId].label : id;

--- a/packages/ai-powerups/src/api/Extension.ts
+++ b/packages/ai-powerups/src/api/Extension.ts
@@ -7,6 +7,9 @@ import { GetSettingsFeature } from "./features/GetSettings/feature.js";
 import { UpdateSettingsFeature } from "./features/UpdateSettings/feature.js";
 import { WbGeneratePageContentFeature } from "./features/WbGeneratePageContent/feature.js";
 import { ProvidersFeature } from "./features/Providers/feature.js";
+import { ConnectionsFeature } from "./features/Connections/feature.js";
+import { ModelRolesFeature } from "./features/ModelRoles/feature.js";
+import { CapabilitiesFeature } from "./features/Capabilities/feature.js";
 import { ReaderPersonasFeature } from "./features/ReaderPersonas/feature.js";
 import { WriterPersonasFeature } from "./features/WriterPersonas/feature.js";
 import { ProjectsFeature } from "./features/Projects/feature.js";
@@ -26,7 +29,15 @@ export const Extension = createFeature({
 
         GetSettingsFeature.register(container);
         UpdateSettingsFeature.register(container);
+        /*
+         * `ProvidersFeature` is still registered so the legacy `providers` section keeps round-
+         * tripping through storage. `Connections` and `ModelRoles` read it once to seed
+         * themselves; nothing else does. It goes away with the next breaking release.
+         */
         ProvidersFeature.register(container);
+        ConnectionsFeature.register(container);
+        ModelRolesFeature.register(container);
+        CapabilitiesFeature.register(container);
         ReaderPersonasFeature.register(container);
         WriterPersonasFeature.register(container);
         ProjectsFeature.register(container);

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
@@ -110,7 +110,7 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
                             },
                             {
                                 type: "text",
-                                text: withAdditionalInstructions(capability.guidance, capability)
+                                text: withAdditionalInstructions(capability)
                             }
                         ]
                     }

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
@@ -2,6 +2,7 @@ import { Output } from "ai";
 import { z } from "zod";
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import { GetFileUseCase } from "@webiny/api-file-manager/features/file/GetFile/index.js";
 import { UpdateFileUseCase } from "@webiny/api-file-manager/features/file/UpdateFile/index.js";
 import { GetSettingsUseCase as FmGetSettingsUseCase } from "@webiny/api-file-manager/features/settings/GetSettings/abstractions.js";
@@ -42,6 +43,7 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
         private updateFile: UpdateFileUseCase.Interface,
         private ai: Ai.Interface,
         private resolveCapability: ResolveAiCapabilityUseCase.Interface,
+        private logger: Logger.Interface,
         private identityContext: IdentityContext.Interface,
         private sendToIdentity: WebsocketsSendToIdentityUseCase.Interface
     ) {}
@@ -82,12 +84,9 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
              * on every upload. Today's behaviour for an unconfigured provider is the same soft
              * done; the log is new, because a skip and a misconfiguration used to look identical.
              */
-            console.error(
-                JSON.stringify({
-                    message: "Skipping AI image enrichment.",
-                    fileId: input.fileId,
-                    reason: resolved.error.message
-                })
+            this.logger.warn(
+                { fileId: input.fileId, reason: resolved.error.message },
+                "Skipping AI image enrichment."
             );
             return controller.response.done(resolved.error.message);
         }
@@ -166,6 +165,7 @@ export const AiImageEnrichmentTask = TaskDefinition.createImplementation({
         UpdateFileUseCase,
         Ai,
         ResolveAiCapabilityUseCase,
+        Logger,
         IdentityContext,
         WebsocketsSendToIdentityUseCase
     ]

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
@@ -2,18 +2,18 @@ import { Output } from "ai";
 import { z } from "zod";
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetFileUseCase } from "@webiny/api-file-manager/features/file/GetFile/index.js";
 import { UpdateFileUseCase } from "@webiny/api-file-manager/features/file/UpdateFile/index.js";
 import { GetSettingsUseCase as FmGetSettingsUseCase } from "@webiny/api-file-manager/features/settings/GetSettings/abstractions.js";
 import { WebsocketsSendToIdentityUseCase } from "@webiny/api-websockets/features/SendToIdentity/abstractions.js";
 import { IdentityContext } from "@webiny/api-core/exports/api/security.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { FM_IMAGE_ENRICHMENT_CAPABILITY } from "./capability.js";
 
 export const AI_IMAGE_ENRICHMENT_TASK_ID = "fmAiImageEnrichment";
-
-const AI_PROMPT =
-    "Analyze this image and return up to 5 lowercase descriptive tags and one short sentence describing the image.";
 
 const aiOutputSchema = Output.object({
     schema: z.object({
@@ -41,8 +41,7 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
         private fmSettings: FmGetSettingsUseCase.Interface,
         private updateFile: UpdateFileUseCase.Interface,
         private ai: Ai.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
-        private encryption: Encryption.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private identityContext: IdentityContext.Interface,
         private sendToIdentity: WebsocketsSendToIdentityUseCase.Interface
     ) {}
@@ -74,34 +73,34 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
         const srcPrefix = settingsResult.isOk() ? (settingsResult.value.srcPrefix ?? "") : "";
         const imageUrl = `${srcPrefix}${file.key}`;
 
-        const aiSettingsResult = await this.getSettings.execute();
+        const resolved = await this.resolveCapability.execute(FM_IMAGE_ENRICHMENT_CAPABILITY);
 
-        if (aiSettingsResult.isFail()) {
-            return controller.response.error({
-                message: "No AI provider configured. Add a provider in AI Power Ups settings."
-            });
+        if (resolved.isFail()) {
+            /*
+             * A skip, not a failure. This feature is not licence-gated on this branch, so every
+             * project that uploads an image without AI configured would otherwise get a failed task
+             * on every upload. Today's behaviour for an unconfigured provider is the same soft
+             * done; the log is new, because a skip and a misconfiguration used to look identical.
+             */
+            console.error(
+                JSON.stringify({
+                    message: "Skipping AI image enrichment.",
+                    fileId: input.fileId,
+                    reason: resolved.error.message
+                })
+            );
+            return controller.response.done(resolved.error.message);
         }
 
-        const aiSettings = aiSettingsResult.value;
-
-        const firstProvider = aiSettings.providers.presets[0];
-
-        if (!firstProvider) {
-            return controller.response.done({
-                message: "No AI provider configured. Add a provider in AI Power Ups settings."
-            });
-        }
+        const capability = resolved.value;
 
         let tags: string[] = [];
         let description = "";
         try {
             const aiResult = await this.ai.generateText({
-                model: firstProvider.model,
+                model: capability.model,
                 output: aiOutputSchema,
-                connection: {
-                    sdkName: firstProvider.model.split("/")[0],
-                    apiKey: await this.encryption.decrypt(firstProvider.apiKeyEncrypted)
-                },
+                connection: capability.connection,
                 messages: [
                     {
                         role: "user",
@@ -112,7 +111,7 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
                             },
                             {
                                 type: "text",
-                                text: AI_PROMPT
+                                text: withAdditionalInstructions(capability.guidance, capability)
                             }
                         ]
                     }
@@ -166,8 +165,7 @@ export const AiImageEnrichmentTask = TaskDefinition.createImplementation({
         FmGetSettingsUseCase,
         UpdateFileUseCase,
         Ai,
-        GetSettingsUseCase,
-        Encryption,
+        ResolveAiCapabilityUseCase,
         IdentityContext,
         WebsocketsSendToIdentityUseCase
     ]

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/capability.ts
@@ -1,0 +1,28 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const FM_IMAGE_ENRICHMENT_CAPABILITY = "fm.imageEnrichment";
+
+/**
+ * The prompt lives here rather than in the task now, because it is the capability's, and the
+ * resolver hands it back with the project's additional instructions already appended.
+ *
+ * This is the one AI prompt whose structure does not come from the prose: `Output.object(...)` in
+ * the task enforces the tags/description shape. House tag vocabularies go in additional
+ * instructions ("use our taxonomy", "no more than three tags", "British spelling").
+ */
+const guidance =
+    "Analyze this image and return up to 5 lowercase descriptive tags and one short sentence describing the image.";
+
+class FmImageEnrichmentCapabilityImpl implements AiCapability.Interface {
+    readonly id = FM_IMAGE_ENRICHMENT_CAPABILITY;
+    readonly label = "Image enrichment";
+    readonly description =
+        "Reads an uploaded image and writes its alt text, title and tags. Needs a model that accepts image input.";
+    readonly defaultRole = "vision" as const;
+    readonly guidance = guidance;
+}
+
+export const FmImageEnrichmentCapability = AiCapability.createImplementation({
+    implementation: FmImageEnrichmentCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/feature.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { AiImageEnrichmentAfterCreateHandler } from "./AiImageEnrichmentAfterCreateHandler.js";
 import { AiImageEnrichmentTask } from "./AiImageEnrichmentTask.js";
+import { FmImageEnrichmentCapability } from "./capability.js";
 
 export const AiImageEnrichmentFeature = createFeature({
     name: "AiPowerUps/AiImageEnrichment",
     register(container) {
+        container.register(FmImageEnrichmentCapability);
         container.register(AiImageEnrichmentAfterCreateHandler);
         container.register(AiImageEnrichmentTask);
     }

--- a/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/CapabilitiesHandler.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { AI_MODEL_ROLE_IDS } from "~/api/features/ModelRoles/index.js";
+import type { AiCapabilityOverride, CapabilitiesSettings, PersistedCapabilities } from "./types.js";
+
+/*
+ * Every field here is empty by default and the admin form sends `null` for an untouched one, so
+ * each has to accept it. `mapToStorage` drops the nulls rather than persisting them.
+ */
+const overrideSchema = z.object({
+    roleId: z.union([z.enum(AI_MODEL_ROLE_IDS), z.literal("")]).nullish(),
+    connectionId: z.string().nullish(),
+    model: z.string().nullish(),
+    additionalInstructions: z.string().nullish()
+});
+
+const inputSchema = z.object({
+    overrides: z.record(z.string(), overrideSchema)
+});
+
+/** Keeps the persisted blob free of rows that only hold empty strings. */
+const isEmptyOverride = (override: AiCapabilityOverride): boolean =>
+    !override.roleId &&
+    !override.connectionId &&
+    !override.model &&
+    !override.additionalInstructions?.trim();
+
+/**
+ * Keeps values that mean "not set" out of storage. The form sends `null` for an untouched field, and
+ * persisting those would mean every capability a project never configured still occupies a key.
+ */
+const dropEmptyValues = (override: AiCapabilityOverride): AiCapabilityOverride =>
+    Object.fromEntries(
+        Object.entries(override).filter(
+            ([, value]) => value !== null && value !== undefined && value !== ""
+        )
+    ) as AiCapabilityOverride;
+
+class CapabilitiesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "capabilities";
+    readonly inputSchema = inputSchema;
+
+    mapFromStorage(persisted: unknown): CapabilitiesSettings {
+        const stored = (persisted ?? {}) as PersistedCapabilities;
+        return { overrides: stored.overrides ?? {} };
+    }
+
+    async mapToStorage(internal: unknown): Promise<PersistedCapabilities> {
+        const input = internal as CapabilitiesSettings;
+
+        // Normalise before testing for emptiness, so a row of untouched fields disappears rather
+        // than persisting as an override of nothing.
+        const entries = Object.entries(input.overrides ?? {})
+            .filter(([, override]) => Boolean(override))
+            .map(([id, override]) => [id, dropEmptyValues(override)] as const)
+            .filter(([, override]) => !isEmptyOverride(override));
+
+        return { overrides: Object.fromEntries(entries) };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: CapabilitiesHandlerImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/ResolveAiCapabilityUseCase.ts
@@ -1,0 +1,181 @@
+import { Result } from "@webiny/feature/api";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import { sdkNameFromModel } from "~/api/features/Connections/index.js";
+import { AiCapability, ResolveAiCapabilityUseCase } from "./abstractions.js";
+import type { IResolvedAiCapability } from "./abstractions.js";
+import type { AiCapabilityOverride } from "./types.js";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+const SETTINGS_PATH = "Settings → AI Power-Ups";
+
+/**
+ * Turns a capability id into the model, credential and prompt text a use case needs.
+ *
+ * This is the single place that knows the precedence rules. Before it existed, six use cases each
+ * read `providers.presets[0]`, re-derived the SDK name from the model string and decrypted the key
+ * themselves, so "which model runs this feature" had six answers that only happened to agree.
+ *
+ * Precedence: a capability's pinned connection+model, else its chosen role, else its declared
+ * default role, else the `standard` role.
+ *
+ * There is deliberately no environment-variable fallback. A project whose settings say one thing
+ * and whose requests use another is the exact confusion this replaces.
+ */
+class ResolveAiCapabilityUseCaseImpl implements ResolveAiCapabilityUseCase.Interface {
+    private capabilityLookup: Map<string, AiCapability.Interface>;
+
+    constructor(
+        capabilities: AiCapability.Interface[],
+        private getSettings: GetSettingsUseCase.Interface,
+        private encryption: Encryption.Interface
+    ) {
+        this.capabilityLookup = new Map(capabilities.map(c => [c.id, c]));
+    }
+
+    async execute(capabilityId: string): Promise<Result<IResolvedAiCapability, Error>> {
+        const capability = this.capabilityLookup.get(capabilityId);
+
+        if (!capability) {
+            // Nothing a project can do about this one: the caller passed an unregistered id.
+            return Result.fail(
+                new Error(
+                    `Unknown AI capability "${capabilityId}". Register it with the AiCapability abstraction.`
+                )
+            );
+        }
+
+        const settingsResult = await this.getSettings.execute();
+        if (settingsResult.isFail()) {
+            return Result.fail(new Error("Failed to load AI Power-Ups settings."));
+        }
+
+        const settings = settingsResult.value;
+        const override: AiCapabilityOverride =
+            settings.capabilities?.overrides?.[capabilityId] ?? {};
+
+        const selection = this.selectModel(settings, capability.defaultRole, override);
+        if (selection.isFail()) {
+            return Result.fail(selection.error);
+        }
+
+        const { connectionId, model, roleId, fellBackToStandard } = selection.value;
+
+        const connection = settings.connections?.presets?.find(c => c.id === connectionId);
+
+        if (!connection) {
+            return Result.fail(
+                new Error(
+                    `"${capability.label}" points at a connection that no longer exists. Pick one under ${SETTINGS_PATH} → Model roles.`
+                )
+            );
+        }
+
+        if (!connection.apiKeyEncrypted) {
+            return Result.fail(
+                new Error(
+                    `The connection "${connection.name}" has no API key. Add one under ${SETTINGS_PATH} → Connections.`
+                )
+            );
+        }
+
+        /*
+         * A model is stored fully qualified ("anthropic/claude-sonnet-4-5") and a connection stores
+         * its vendor separately, so the two can disagree if a connection is re-pointed at another
+         * vendor after a role was filled. Catching it here beats a provider-side auth error.
+         */
+        const modelSdkName = sdkNameFromModel(model);
+        if (modelSdkName && connection.sdkName && modelSdkName !== connection.sdkName) {
+            return Result.fail(
+                new Error(
+                    `The model "${model}" cannot run on the "${connection.name}" connection, which is a ${connection.sdkName} credential. Fix the pairing under ${SETTINGS_PATH} → Model roles.`
+                )
+            );
+        }
+
+        return Result.ok({
+            capabilityId,
+            model,
+            connection: {
+                sdkName: modelSdkName || connection.sdkName,
+                apiKey: await this.encryption.decrypt(connection.apiKeyEncrypted)
+            },
+            roleId,
+            fellBackToStandard,
+            // Always the capability's own. Projects adjust prompts by appending, never by
+            // replacing, because for most capabilities the prompt is the output contract.
+            guidance: capability.guidance ?? "",
+            additionalInstructions: override.additionalInstructions?.trim() ?? ""
+        });
+    }
+
+    private selectModel(
+        settings: IAiPowerUpsSettings,
+        defaultRole: AiModelRoleId,
+        override: AiCapabilityOverride
+    ): Result<
+        {
+            connectionId: string;
+            model: string;
+            roleId: AiModelRoleId | null;
+            fellBackToStandard: boolean;
+        },
+        Error
+    > {
+        // A pinned connection+model wins outright. Both halves are required; one alone is a
+        // half-finished edit, so it is ignored rather than guessed at.
+        if (override.connectionId && override.model) {
+            return Result.ok({
+                connectionId: override.connectionId,
+                model: override.model,
+                roleId: null,
+                fellBackToStandard: false
+            });
+        }
+
+        const roles = settings.modelRoles?.roles;
+        const requestedRole = (override.roleId || defaultRole) as AiModelRoleId;
+        const requested = roles?.[requestedRole];
+
+        if (requested?.connectionId && requested.model) {
+            return Result.ok({
+                connectionId: requested.connectionId,
+                model: requested.model,
+                roleId: requestedRole,
+                fellBackToStandard: false
+            });
+        }
+
+        /*
+         * An unfilled role falls back to `standard` rather than failing. That is what keeps an
+         * upgrade quiet: migration fills only `standard`, and every feature that used to read
+         * `providers.presets[0]` keeps running on exactly the model it ran on before.
+         *
+         * It does mean an unfilled `vision` role sends images to whatever `standard` holds. Same
+         * as today's behaviour, and the settings screen says so next to the role.
+         */
+        const standard = roles?.standard;
+
+        if (standard?.connectionId && standard.model) {
+            return Result.ok({
+                connectionId: standard.connectionId,
+                model: standard.model,
+                roleId: "standard",
+                fellBackToStandard: requestedRole !== "standard"
+            });
+        }
+
+        return Result.fail(
+            new Error(
+                `No model is configured for the "${requestedRole}" role. Pick one under ${SETTINGS_PATH} → Model roles.`
+            )
+        );
+    }
+}
+
+export const ResolveAiCapabilityUseCaseImplementation =
+    ResolveAiCapabilityUseCase.createImplementation({
+        implementation: ResolveAiCapabilityUseCaseImpl,
+        dependencies: [[AiCapability, { multiple: true }], GetSettingsUseCase, Encryption]
+    });

--- a/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/abstractions.ts
@@ -1,0 +1,65 @@
+import { createAbstraction, Result } from "@webiny/feature/api";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+
+/**
+ * One AI feature, declared so the settings screen can list it and a project can point it at a
+ * different model or adjust its prompt.
+ *
+ * Features register these; nothing hardcodes the list. An extension that adds an AI feature gets a
+ * row in Settings for free by registering a capability alongside it.
+ */
+export interface IAiCapability {
+    /** Stable, namespaced, and persisted as a settings key. Renaming one orphans its overrides. */
+    readonly id: string;
+    readonly label: string;
+    readonly description: string;
+    /** Which role supplies the model when the project has not overridden this capability. */
+    readonly defaultRole: AiModelRoleId;
+    /**
+     * The capability's fixed system-prompt block, owned by the code and not configurable.
+     *
+     * Leave it undefined when the prompt is assembled per request (from a content model schema, a
+     * component catalog, a persona) and the use case builds its own system text instead.
+     *
+     * Either way a project can only append to it, via `additionalInstructions`. These prompts carry
+     * the output contract the surrounding code parses, so they are implementation, not settings.
+     */
+    readonly guidance?: string;
+}
+
+export const AiCapability = createAbstraction<IAiCapability>("AiPowerUpsAiCapability");
+
+export namespace AiCapability {
+    export type Interface = IAiCapability;
+}
+
+export interface IResolvedAiCapability {
+    capabilityId: string;
+    /** Fully qualified, e.g. `"anthropic/claude-sonnet-4-5"`. */
+    model: string;
+    connection: {
+        sdkName: string;
+        apiKey: string;
+    };
+    /** Which role supplied the model. `null` when a capability override pinned it directly. */
+    roleId: AiModelRoleId | null;
+    /** True when the requested role was empty and `standard` filled in for it. */
+    fellBackToStandard: boolean;
+    /** The capability's own guidance. Empty when it assembles its prompt per request. */
+    guidance: string;
+    /** Project text to append to the system prompt. Empty when unset. */
+    additionalInstructions: string;
+}
+
+export interface IResolveAiCapabilityUseCase {
+    execute(capabilityId: string): Promise<Result<IResolvedAiCapability, Error>>;
+}
+
+export const ResolveAiCapabilityUseCase = createAbstraction<IResolveAiCapabilityUseCase>(
+    "AiPowerUpsResolveAiCapabilityUseCase"
+);
+
+export namespace ResolveAiCapabilityUseCase {
+    export type Interface = IResolveAiCapabilityUseCase;
+    export type Resolution = IResolvedAiCapability;
+}

--- a/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
@@ -1,0 +1,26 @@
+import type { IResolvedAiCapability } from "./abstractions.js";
+
+/**
+ * Appends a project's additional instructions to a system prompt.
+ *
+ * Appending is the default way a project adjusts a prompt, and the reason is upgrades: a project
+ * that appends keeps getting our prompt improvements, while a project that replaces the prompt is
+ * frozen at whatever we shipped the day they edited it. The heading is there so the model reads the
+ * project's text as instructions rather than as more of ours.
+ */
+export const withAdditionalInstructions = (
+    systemText: string,
+    resolved: Pick<IResolvedAiCapability, "additionalInstructions">
+): string => {
+    if (!resolved.additionalInstructions) {
+        return systemText;
+    }
+
+    return `${systemText}
+
+### Project instructions
+
+These come from this project's settings and take precedence over the general guidance above.
+
+${resolved.additionalInstructions}`;
+};

--- a/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/composeSystemPrompt.ts
@@ -1,22 +1,26 @@
 import type { IResolvedAiCapability } from "./abstractions.js";
 
 /**
- * Appends a project's additional instructions to a system prompt.
+ * Appends a project's additional instructions to a capability's system prompt.
  *
- * Appending is the default way a project adjusts a prompt, and the reason is upgrades: a project
- * that appends keeps getting our prompt improvements, while a project that replaces the prompt is
- * frozen at whatever we shipped the day they edited it. The heading is there so the model reads the
+ * Appending is the only way a project adjusts a prompt, and the reason is upgrades: a project that
+ * appends keeps getting our prompt improvements, while one that replaced the prompt would be frozen
+ * at whatever we shipped the day they edited it. The heading is there so the model reads the
  * project's text as instructions rather than as more of ours.
+ *
+ * `baseText` defaults to the capability's own guidance, which is what most callers want. The two
+ * generation use cases pass their own, because they build a prompt per request from a content model
+ * schema or a component catalog and the capability declares no fixed guidance of its own.
  */
 export const withAdditionalInstructions = (
-    systemText: string,
-    resolved: Pick<IResolvedAiCapability, "additionalInstructions">
+    resolved: Pick<IResolvedAiCapability, "guidance" | "additionalInstructions">,
+    baseText: string = resolved.guidance
 ): string => {
     if (!resolved.additionalInstructions) {
-        return systemText;
+        return baseText;
     }
 
-    return `${systemText}
+    return `${baseText}
 
 ### Project instructions
 

--- a/packages/ai-powerups/src/api/features/Capabilities/feature.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/feature.ts
@@ -1,0 +1,11 @@
+import { createFeature } from "@webiny/feature/api";
+import CapabilitiesHandler from "./CapabilitiesHandler.js";
+import { ResolveAiCapabilityUseCaseImplementation } from "./ResolveAiCapabilityUseCase.js";
+
+export const CapabilitiesFeature = createFeature({
+    name: "AiPowerUpsCapabilities",
+    register(container) {
+        container.register(CapabilitiesHandler);
+        container.register(ResolveAiCapabilityUseCaseImplementation);
+    }
+});

--- a/packages/ai-powerups/src/api/features/Capabilities/index.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/index.ts
@@ -1,0 +1,5 @@
+export { AiCapability, ResolveAiCapabilityUseCase } from "./abstractions.js";
+export type { IAiCapability, IResolvedAiCapability } from "./abstractions.js";
+export { withAdditionalInstructions } from "./composeSystemPrompt.js";
+export type { AiCapabilityOverride, CapabilitiesSettings } from "./types.js";
+export { CapabilitiesFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/Capabilities/types.ts
+++ b/packages/ai-powerups/src/api/features/Capabilities/types.ts
@@ -1,0 +1,44 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+import type { AiModelRoleId } from "~/api/features/ModelRoles/index.js";
+
+/**
+ * What a project changed about one capability. Every field is optional and empty by default: an
+ * untouched capability runs on its declared role with its declared prompt.
+ */
+export interface AiCapabilityOverride {
+    /** Run this capability on a different role. Empty means use the capability's default. */
+    roleId?: AiModelRoleId | "";
+    /** Pin an exact connection, bypassing roles entirely. Requires `model` too. */
+    connectionId?: string;
+    /** Pin an exact model. Only read when `connectionId` is also set. */
+    model?: string;
+    /**
+     * Appended to the capability's prompt.
+     *
+     * The only prompt customisation there is, and deliberately so. Replacing a prompt outright
+     * used to be offered here and is not any more: for most capabilities the prompt *is* the output
+     * contract the surrounding code parses, so replacing it means replacing part of the
+     * implementation. Revision comparison regex-matches the HTML table its prompt specifies, and
+     * page translation `JSON.parse`s a shape its prompt dictates, both failing silently if the
+     * format goes away. Appending leaves the contract in place.
+     *
+     * A project that genuinely needs different behaviour decorates the use case in code, which is
+     * how the AI translation itself is built.
+     */
+    additionalInstructions?: string;
+}
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        capabilities: {
+            /** Keyed by capability id. */
+            overrides: Record<string, AiCapabilityOverride>;
+        };
+    }
+}
+
+export type CapabilitiesSettings = IAiPowerUpsSettings["capabilities"];
+
+export interface PersistedCapabilities {
+    overrides?: Record<string, AiCapabilityOverride>;
+}

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
@@ -77,7 +77,7 @@ ${JSON.stringify(revision2.values, null, 2)}`;
         const result = await this.ai.generateText({
             model: capability.model,
             connection: capability.connection,
-            system: withAdditionalInstructions(capability.guidance, capability),
+            system: withAdditionalInstructions(capability),
             prompt: userPrompt,
             temperature: 0.3
         });

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/CmsCompareEntryRevisionsUseCase.ts
@@ -1,68 +1,23 @@
 import { Ai } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { ModelToAstConverter } from "@webiny/api-headless-cms/features/contentModel/ModelToAstConverter/index.js";
 import { CmsModelToJsonSchemaConverter } from "@webiny/api-headless-cms/utils/contentModelToJsonSchema/index.js";
 import { GetRevisionByIdUseCase } from "@webiny/api-headless-cms/features/contentEntry/GetRevisionById/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY } from "./capability.js";
 import { CmsCompareEntryRevisionsUseCase } from "./abstractions.js";
 import type {
     ICmsCompareEntryRevisionsParams,
     ICmsCompareEntryRevisionsResult
 } from "./abstractions.js";
 
-const SYSTEM_PROMPT = `You are a content intelligence assistant specialized in version comparison for headless CMS platforms.
-
-I will provide:
-
-1. The content model JSON Schema that defines the structure of the entry.
-2. Two versions of the content entry values in JSON format: Version A and Version B.
-
-Your task:
-
-- Parse both versions according to the JSON Schema.
-- Identify all differences between Version A and Version B.
-- For each difference, explain:
-    - The field name (use the human-readable label from the schema description if available)
-    - The value in Version A
-    - The value in Version B
-    - A brief summary of the change (e.g., "Title changed from 'Old' to 'New'")
-- If nested fields or objects exist, perform a deep comparison.
-- Return the comparison in clean HTML format.
-
-Output format:
-
-<div class="comparison-report">
-    <table class="comparison-table">
-        <thead>
-            <tr>
-                <th>Field</th>
-                <th>Version A</th>
-                <th>Version B</th>
-                <th>Change Summary</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><strong>title</strong></td>
-                <td>Launch Plan</td>
-                <td>Updated Launch Plan</td>
-                <td>Title changed from 'Launch Plan' to 'Updated Launch Plan'</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-If no differences are found, return: <div class="no-changes"><h3>No differences detected between Version A and Version B.</h3></div>
-
-Use semantic HTML with appropriate CSS classes for styling. Do not include <style> tags or CSS — only return the HTML structure.
-For rich text or complex nested values, show a concise summary rather than raw JSON.`;
-
 class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUseCase.Interface {
     constructor(
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
-        private encryption: Encryption.Interface,
         private getModel: GetModelUseCase.Interface,
         private getRevisionById: GetRevisionByIdUseCase.Interface,
         private modelToAst: ModelToAstConverter.Interface
@@ -73,17 +28,14 @@ class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUse
     ): Promise<ICmsCompareEntryRevisionsResult> {
         const { modelId, revisionId1, revisionId2 } = params;
 
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            throw new Error("Failed to load AI Power Ups settings.");
+        const resolved = await this.resolveCapability.execute(
+            CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY
+        );
+        if (resolved.isFail()) {
+            throw resolved.error;
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            throw new Error("No AI provider configured. Add a provider in AI Power Ups settings.");
-        }
+        const capability = resolved.value;
 
         const modelResult = await this.getModel.execute(modelId);
         if (modelResult.isFail()) {
@@ -113,8 +65,6 @@ class CmsCompareEntryRevisionsUseCaseImpl implements CmsCompareEntryRevisionsUse
             description: model.description
         });
 
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
-
         const userPrompt = `CONTENT MODEL JSON SCHEMA:
 ${JSON.stringify(entrySchema, null, 2)}
 
@@ -125,12 +75,9 @@ VERSION B (Revision #${revision2.version}):
 ${JSON.stringify(revision2.values, null, 2)}`;
 
         const result = await this.ai.generateText({
-            model: firstProvider.model,
-            connection: {
-                sdkName: firstProvider.model.split("/")[0],
-                apiKey
-            },
-            system: SYSTEM_PROMPT,
+            model: capability.model,
+            connection: capability.connection,
+            system: withAdditionalInstructions(capability.guidance, capability),
             prompt: userPrompt,
             temperature: 0.3
         });
@@ -159,9 +106,8 @@ export const CmsCompareEntryRevisionsUseCaseImplementation =
     CmsCompareEntryRevisionsUseCase.createImplementation({
         implementation: CmsCompareEntryRevisionsUseCaseImpl,
         dependencies: [
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
-            Encryption,
             GetModelUseCase,
             GetRevisionByIdUseCase,
             ModelToAstConverter

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/capability.ts
@@ -1,0 +1,69 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY = "cms.compareEntryRevisions";
+
+/**
+ * The output contract lives in this prompt: the use case regex-matches the HTML table it specifies
+ * to build the summary, down to the literal "No differences detected" sentence and a count of
+ * `<tr>` tags, and the dialog styles those classes. That is why a project can only append to it.
+ */
+const guidance = `You are a content intelligence assistant specialized in version comparison for headless CMS platforms.
+
+I will provide:
+
+1. The content model JSON Schema that defines the structure of the entry.
+2. Two versions of the content entry values in JSON format: Version A and Version B.
+
+Your task:
+
+- Parse both versions according to the JSON Schema.
+- Identify all differences between Version A and Version B.
+- For each difference, explain:
+    - The field name (use the human-readable label from the schema description if available)
+    - The value in Version A
+    - The value in Version B
+    - A brief summary of the change (e.g., "Title changed from 'Old' to 'New'")
+- If nested fields or objects exist, perform a deep comparison.
+- Return the comparison in clean HTML format.
+
+Output format:
+
+<div class="comparison-report">
+    <table class="comparison-table">
+        <thead>
+            <tr>
+                <th>Field</th>
+                <th>Version A</th>
+                <th>Version B</th>
+                <th>Change Summary</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>title</strong></td>
+                <td>Launch Plan</td>
+                <td>Updated Launch Plan</td>
+                <td>Title changed from 'Launch Plan' to 'Updated Launch Plan'</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+If no differences are found, return: <div class="no-changes"><h3>No differences detected between Version A and Version B.</h3></div>
+
+Use semantic HTML with appropriate CSS classes for styling. Do not include <style> tags or CSS — only return the HTML structure.
+For rich text or complex nested values, show a concise summary rather than raw JSON.`;
+
+class CmsCompareEntryRevisionsCapabilityImpl implements AiCapability.Interface {
+    readonly id = CMS_COMPARE_ENTRY_REVISIONS_CAPABILITY;
+    readonly label = "CMS revision comparison";
+    readonly description =
+        "Summarises what changed between two revisions of an entry. Short, structural work that a smaller model handles well.";
+    readonly defaultRole = "fast" as const;
+    readonly guidance = guidance;
+}
+
+export const CmsCompareEntryRevisionsCapability = AiCapability.createImplementation({
+    implementation: CmsCompareEntryRevisionsCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/feature.ts
+++ b/packages/ai-powerups/src/api/features/CmsCompareEntryRevisions/feature.ts
@@ -1,9 +1,11 @@
 import { createFeature } from "@webiny/feature/api";
 import { CmsCompareEntryRevisionsUseCaseImplementation } from "./CmsCompareEntryRevisionsUseCase.js";
+import { CmsCompareEntryRevisionsCapability } from "./capability.js";
 
 export const CmsCompareEntryRevisionsFeature = createFeature({
     name: "AiPowerUps/CmsCompareEntryRevisions",
     register(container) {
+        container.register(CmsCompareEntryRevisionsCapability);
         container.register(CmsCompareEntryRevisionsUseCaseImplementation);
     }
 });

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
@@ -3,12 +3,15 @@ import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
 import { AiSdkTools } from "@webiny/api-core/features/ai/index.js";
 import { AiToolPipelineRunner } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { ListTagsUseCase } from "@webiny/api-file-manager/features/file/ListTags/index.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { ModelToAstConverter } from "@webiny/api-headless-cms/features/contentModel/ModelToAstConverter/index.js";
 import { CmsModelToJsonSchemaConverter } from "@webiny/api-headless-cms/utils/contentModelToJsonSchema/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { CMS_GENERATE_ENTRY_CAPABILITY } from "./capability.js";
 import {
     AiPromptContextBuilder,
     formatAdditionalFilesContext
@@ -27,10 +30,9 @@ import { injectDynamicZoneTypenames } from "./injectDynamicZoneTypenames.js";
 class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCase.Interface {
     constructor(
         private promptContextBuilder: AiPromptContextBuilder.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
         private aiSdkTools: AiSdkTools.Interface,
-        private encryption: Encryption.Interface,
         private listTags: ListTagsUseCase.Interface,
         private getModel: GetModelUseCase.Interface,
         private modelToAst: ModelToAstConverter.Interface,
@@ -40,19 +42,12 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
     async execute<TValues = Record<string, any>>(
         params: CmsGenerateEntryContentParams
     ): Promise<Result<GenerateEntryContentResult<TValues>, Error>> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            return Result.fail(new Error("Failed to load AI PowerUps settings."));
+        const resolved = await this.resolveCapability.execute(CMS_GENERATE_ENTRY_CAPABILITY);
+        if (resolved.isFail()) {
+            return Result.fail(resolved.error);
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return Result.fail(
-                new Error("No AI provider configured. Add a provider in AI Power Ups settings.")
-            );
-        }
+        const capability = resolved.value;
 
         const modelResult = await this.getModel.execute(params.modelId);
         if (modelResult.isFail()) {
@@ -67,7 +62,6 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
             description: model.description
         });
 
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
         const sdkTools = this.aiSdkTools.getToolSet();
 
         const context = await this.promptContextBuilder.execute({
@@ -92,8 +86,10 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
         });
         const imageTags = tagsResult.isOk() ? tagsResult.value.map(t => t.tag) : [];
 
-        const systemText =
-            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString();
+        const systemText = withAdditionalInstructions(
+            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString(),
+            capability
+        );
 
         const system = {
             role: "system" as const,
@@ -107,11 +103,8 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
 
         try {
             const aiResult = await this.ai.generateText({
-                model: firstProvider.model,
-                connection: {
-                    sdkName: firstProvider.model.split("/")[0],
-                    apiKey
-                },
+                model: capability.model,
+                connection: capability.connection,
                 system,
                 toolChoice: "auto",
                 prompt: params.prompt + formatAdditionalFilesContext(context.additionalFiles),
@@ -174,10 +167,9 @@ export const CmsGenerateEntryContentUseCaseImplementation =
         implementation: CmsGenerateEntryContentUseCaseImpl,
         dependencies: [
             AiPromptContextBuilder,
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
             AiSdkTools,
-            Encryption,
             ListTagsUseCase,
             GetModelUseCase,
             ModelToAstConverter,

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
@@ -87,8 +87,8 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
         const imageTags = tagsResult.isOk() ? tagsResult.value.map(t => t.tag) : [];
 
         const systemText = withAdditionalInstructions(
-            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString(),
-            capability
+            capability,
+            buildEntryPrompt(model.name, entrySchema, imageTags) + context.toString()
         );
 
         const system = {

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/capability.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/capability.ts
@@ -1,0 +1,21 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const CMS_GENERATE_ENTRY_CAPABILITY = "cms.generateEntry";
+
+/**
+ * No `guidance`: this prompt is rebuilt on every request from the content model's JSON Schema and
+ * the File Manager's current image tags, so there is no fixed block a project could replace without
+ * dropping the schema the output has to conform to. Additional instructions still apply.
+ */
+class CmsGenerateEntryCapabilityImpl implements AiCapability.Interface {
+    readonly id = CMS_GENERATE_ENTRY_CAPABILITY;
+    readonly label = "CMS entry generation";
+    readonly description =
+        "Writes a content entry from a prompt, following the content model's schema and picking images from the File Manager.";
+    readonly defaultRole = "standard" as const;
+}
+
+export const CmsGenerateEntryCapability = AiCapability.createImplementation({
+    implementation: CmsGenerateEntryCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/feature.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { CmsGenerateEntryContentUseCaseImplementation } from "./CmsGenerateEntryContentUseCase.js";
 import { CmsGenerateEntryContentTask } from "./CmsGenerateEntryContentTask.js";
+import { CmsGenerateEntryCapability } from "./capability.js";
 
 export const CmsGenerateEntryContentFeature = createFeature({
     name: "AiPowerUps/CmsGenerateEntryContent",
     register(container) {
+        container.register(CmsGenerateEntryCapability);
         container.register(CmsGenerateEntryContentUseCaseImplementation);
         container.register(CmsGenerateEntryContentTask);
     }

--- a/packages/ai-powerups/src/api/features/Connections/ConnectionsGraphQLMapper.ts
+++ b/packages/ai-powerups/src/api/features/Connections/ConnectionsGraphQLMapper.ts
@@ -1,0 +1,56 @@
+import { AiPowerUpsSettingsGroupGraphQLMapper } from "~/api/features/shared/index.js";
+import type { ConnectionsSettings } from "./types.js";
+
+interface ApiConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKey: string | null;
+}
+
+interface ApiConnections {
+    presets: ApiConnectionPreset[];
+}
+
+interface ApiInputConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKey?: string;
+}
+
+class ConnectionsGraphQLMapperImpl implements AiPowerUpsSettingsGroupGraphQLMapper.Interface {
+    readonly name = "connections";
+
+    toApi(internal: unknown): ApiConnections {
+        const data = internal as ConnectionsSettings;
+        return {
+            presets: data.presets.map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: p.sdkName,
+                // The admin form only ever sees the mask. The plaintext key never leaves the api.
+                apiKey: p.apiKeyMasked ?? null
+            }))
+        };
+    }
+
+    fromApi(api: unknown): ConnectionsSettings {
+        const data = api as { presets: ApiInputConnectionPreset[] };
+        return {
+            presets: data.presets.map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: p.sdkName,
+                apiKey: p.apiKey,
+                apiKeyMasked: "",
+                apiKeyEncrypted: ""
+            }))
+        };
+    }
+}
+
+export default AiPowerUpsSettingsGroupGraphQLMapper.createImplementation({
+    implementation: ConnectionsGraphQLMapperImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
+++ b/packages/ai-powerups/src/api/features/Connections/ConnectionsHandler.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { Encryption } from "@webiny/api-core/features/encryption/index.js";
+import { Masker } from "@webiny/api-core/features/masker/index.js";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { readLegacyProviderPresets, sdkNameFromModel } from "./types.js";
+import type {
+    ConnectionsSettings,
+    PersistedAiConnectionPreset,
+    PersistedConnections
+} from "./types.js";
+
+const inputSchema = z.object({
+    presets: z.array(
+        z.object({
+            id: z.string().min(1),
+            name: z.string().min(1),
+            sdkName: z.string().min(1),
+            apiKey: z.string().nullish()
+        })
+    )
+});
+
+class ConnectionsHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "connections";
+    readonly inputSchema = inputSchema;
+
+    constructor(
+        private encryption: Encryption.Interface,
+        private masker: Masker.Interface
+    ) {}
+
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): ConnectionsSettings {
+        if (persisted && typeof persisted === "object") {
+            const data = persisted as PersistedConnections;
+            return {
+                presets: (data.presets ?? []).map(p => ({
+                    id: p.id,
+                    name: p.name,
+                    sdkName: p.sdkName,
+                    apiKeyMasked: p.apiKeyMasked ?? "",
+                    apiKeyEncrypted: p.apiKeyEncrypted ?? ""
+                }))
+            };
+        }
+
+        /*
+         * No `connections` section yet, so derive one from the legacy `providers` presets. The keys
+         * are already encrypted in storage, which is why this can be a pure read: nothing has to be
+         * re-encrypted, and nothing is written back until the next save.
+         *
+         * Dropping the model here is safe. `ModelRoles` reads the same legacy section and lifts
+         * the first preset's model into the `standard` role, which is the only model the old code
+         * ever used.
+         */
+        return {
+            presets: readLegacyProviderPresets(all).map(p => ({
+                id: p.id,
+                name: p.name,
+                sdkName: sdkNameFromModel(p.model),
+                apiKeyMasked: p.apiKeyMasked ?? "",
+                apiKeyEncrypted: p.apiKeyEncrypted ?? ""
+            }))
+        };
+    }
+
+    async mapToStorage(internal: unknown, existing: unknown | null): Promise<PersistedConnections> {
+        const input = internal as ConnectionsSettings;
+        const existingPresets = (existing as ConnectionsSettings | null)?.presets ?? [];
+
+        const presets: PersistedAiConnectionPreset[] = await Promise.all(
+            input.presets.map(async preset => {
+                const existingMatch = existingPresets.find(ep => ep.id === preset.id);
+
+                let apiKeyEncrypted: string;
+                let apiKeyMasked: string;
+
+                if (!preset.apiKey || preset.apiKey === existingMatch?.apiKeyMasked) {
+                    // The form sends back the mask when the key was left alone. Carry it forward.
+                    apiKeyEncrypted = existingMatch?.apiKeyEncrypted ?? "";
+                    apiKeyMasked = existingMatch?.apiKeyMasked ?? "";
+                } else {
+                    apiKeyEncrypted = await this.encryption.encrypt(preset.apiKey);
+                    apiKeyMasked = this.masker.mask(preset.apiKey, [8, 4]);
+                }
+
+                return {
+                    id: preset.id,
+                    name: preset.name,
+                    sdkName: preset.sdkName,
+                    apiKeyEncrypted,
+                    apiKeyMasked
+                };
+            })
+        );
+
+        return { presets };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: ConnectionsHandlerImpl,
+    dependencies: [Encryption, Masker]
+});

--- a/packages/ai-powerups/src/api/features/Connections/feature.ts
+++ b/packages/ai-powerups/src/api/features/Connections/feature.ts
@@ -1,0 +1,11 @@
+import { createFeature } from "@webiny/feature/api";
+import ConnectionsHandler from "./ConnectionsHandler.js";
+import ConnectionsGraphQLMapper from "./ConnectionsGraphQLMapper.js";
+
+export const ConnectionsFeature = createFeature({
+    name: "AiPowerUpsConnections",
+    register(container) {
+        container.register(ConnectionsHandler);
+        container.register(ConnectionsGraphQLMapper);
+    }
+});

--- a/packages/ai-powerups/src/api/features/Connections/index.ts
+++ b/packages/ai-powerups/src/api/features/Connections/index.ts
@@ -1,0 +1,3 @@
+export type { AiConnectionPreset, ConnectionsSettings } from "./types.js";
+export { sdkNameFromModel } from "./types.js";
+export { ConnectionsFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/Connections/types.ts
+++ b/packages/ai-powerups/src/api/features/Connections/types.ts
@@ -1,0 +1,66 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+
+/**
+ * A connection is one credential for one vendor. It carries no model.
+ *
+ * The section it replaces (`providers`) bundled a key with a single model, so a project that wanted
+ * two Anthropic models had to paste the same key twice and keep both copies in sync. Splitting the
+ * two means the key is entered once and every model that vendor offers is then selectable.
+ */
+export interface AiConnectionPreset {
+    id: string;
+    name: string;
+    /** AI SDK namespace, e.g. "anthropic" or "openai". Matches `AiSdkFactory.id`. */
+    sdkName: string;
+    /** Plaintext. Only ever set on the way in from the admin form, never persisted. */
+    apiKey?: string;
+    apiKeyMasked: string;
+    apiKeyEncrypted: string;
+}
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        connections: {
+            presets: AiConnectionPreset[];
+        };
+    }
+}
+
+export type ConnectionsSettings = IAiPowerUpsSettings["connections"];
+
+export interface PersistedAiConnectionPreset {
+    id: string;
+    name: string;
+    sdkName: string;
+    apiKeyEncrypted: string;
+    apiKeyMasked: string;
+}
+
+export interface PersistedConnections {
+    presets: PersistedAiConnectionPreset[];
+}
+
+/** Shape of a preset in the legacy `providers` section, read once for migration. */
+export interface LegacyProviderPreset {
+    id: string;
+    name: string;
+    model?: string;
+    apiKeyEncrypted?: string;
+    apiKeyMasked?: string;
+}
+
+export const readLegacyProviderPresets = (
+    all: Record<string, unknown> | undefined
+): LegacyProviderPreset[] => {
+    const providers = all?.["providers"];
+    if (!providers || typeof providers !== "object") {
+        return [];
+    }
+
+    const presets = (providers as { presets?: unknown }).presets;
+    return Array.isArray(presets) ? (presets as LegacyProviderPreset[]) : [];
+};
+
+/** `"anthropic/claude-sonnet-4-5"` -> `"anthropic"`. */
+export const sdkNameFromModel = (model: string | undefined): string =>
+    (model ?? "").split("/")[0] ?? "";

--- a/packages/ai-powerups/src/api/features/GetSettings/GetSettingsRepository.ts
+++ b/packages/ai-powerups/src/api/features/GetSettings/GetSettingsRepository.ts
@@ -30,7 +30,7 @@ class GetSettingsRepositoryImpl implements GetSettingsRepository.Interface {
         const result: Record<string, unknown> = {};
 
         for (const handler of this.handlers) {
-            result[handler.name] = handler.mapFromStorage(raw[handler.name]);
+            result[handler.name] = handler.mapFromStorage(raw[handler.name], raw);
         }
 
         for (const key of Object.keys(raw)) {

--- a/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/ModelRolesHandler.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
+import { readLegacyProviderPresets } from "~/api/features/Connections/types.js";
+import { AI_MODEL_ROLE_IDS } from "./roles.js";
+import { emptyAssignment } from "./types.js";
+import type { AiModelRoleAssignments, ModelRolesSettings, PersistedModelRoles } from "./types.js";
+
+/*
+ * The admin form sends `null`, not `""`, for a field nobody has touched, and an unfilled role is
+ * the normal state of two of the three. `nullish` keeps an untouched role from failing validation;
+ * `mapToStorage` is what normalises it to `""`.
+ */
+const formString = z.string().nullish();
+
+const assignmentSchema = z.object({
+    connectionId: formString,
+    model: formString
+});
+
+const inputSchema = z.object({
+    roles: z.object(
+        Object.fromEntries(AI_MODEL_ROLE_IDS.map(id => [id, assignmentSchema]))
+    ) as unknown as z.ZodType<AiModelRoleAssignments>
+});
+
+class ModelRolesHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
+    readonly name = "modelRoles";
+    readonly inputSchema = inputSchema;
+
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): ModelRolesSettings {
+        const stored = (persisted ?? {}) as PersistedModelRoles;
+        const roles = Object.fromEntries(
+            AI_MODEL_ROLE_IDS.map(id => {
+                const assignment = stored.roles?.[id];
+                return [
+                    id,
+                    {
+                        connectionId: assignment?.connectionId ?? "",
+                        model: assignment?.model ?? ""
+                    }
+                ];
+            })
+        ) as AiModelRoleAssignments;
+
+        if (roles.standard.model) {
+            return { roles };
+        }
+
+        /*
+         * Nothing has filled `standard` yet, so seed it from the legacy `providers` section. Every
+         * AI feature used to read `providers.presets[0]` and nothing else, so lifting exactly that
+         * preset into `standard` reproduces the old behaviour for a project that upgrades without
+         * touching the settings screen.
+         *
+         * `fast` and `vision` stay empty on purpose. Both fall back to `standard` at resolve time,
+         * so an untouched project keeps working, and the settings screen shows the fallback rather
+         * than pretending someone chose it.
+         */
+        const legacy = readLegacyProviderPresets(all)[0];
+
+        if (legacy?.model) {
+            roles.standard = { connectionId: legacy.id, model: legacy.model };
+        }
+
+        return { roles };
+    }
+
+    async mapToStorage(internal: unknown): Promise<PersistedModelRoles> {
+        const input = internal as ModelRolesSettings;
+
+        return {
+            roles: Object.fromEntries(
+                AI_MODEL_ROLE_IDS.map(id => {
+                    const assignment = input.roles?.[id] ?? emptyAssignment();
+                    return [
+                        id,
+                        {
+                            connectionId: assignment.connectionId ?? "",
+                            model: assignment.model ?? ""
+                        }
+                    ];
+                })
+            )
+        };
+    }
+}
+
+export default AiPowerUpsSettingsGroupHandler.createImplementation({
+    implementation: ModelRolesHandlerImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/ModelRoles/feature.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import ModelRolesHandler from "./ModelRolesHandler.js";
+
+export const ModelRolesFeature = createFeature({
+    name: "AiPowerUpsModelRoles",
+    register(container) {
+        container.register(ModelRolesHandler);
+    }
+});

--- a/packages/ai-powerups/src/api/features/ModelRoles/index.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/index.ts
@@ -1,0 +1,4 @@
+export { AI_MODEL_ROLE_IDS, isAiModelRoleId } from "./roles.js";
+export type { AiModelRoleId } from "./roles.js";
+export type { AiModelRoleAssignment, AiModelRoleAssignments, ModelRolesSettings } from "./types.js";
+export { ModelRolesFeature } from "./feature.js";

--- a/packages/ai-powerups/src/api/features/ModelRoles/roles.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/roles.ts
@@ -1,0 +1,19 @@
+/**
+ * Model roles are the indirection between an AI feature and a concrete model.
+ *
+ * A feature never names a model. It names a role, and the project decides which model fills that
+ * role. That keeps the settings screen small (one select per role, not one per feature) while still
+ * letting a project run cheap work on a cheap model.
+ *
+ * The set is deliberately fixed and closed. A project that needs a different model for one specific
+ * feature overrides that feature under Capabilities instead of inventing a role.
+ *
+ * Labels and descriptions are not here on purpose: they are UI text, and they live next to the
+ * settings form in `~/admin/presentation/modelRoles.js`.
+ */
+export const AI_MODEL_ROLE_IDS = ["fast", "standard", "vision"] as const;
+
+export type AiModelRoleId = (typeof AI_MODEL_ROLE_IDS)[number];
+
+export const isAiModelRoleId = (value: unknown): value is AiModelRoleId =>
+    typeof value === "string" && (AI_MODEL_ROLE_IDS as readonly string[]).includes(value);

--- a/packages/ai-powerups/src/api/features/ModelRoles/types.ts
+++ b/packages/ai-powerups/src/api/features/ModelRoles/types.ts
@@ -1,0 +1,27 @@
+import type { IAiPowerUpsSettings } from "~/api/types.js";
+import type { AiModelRoleId } from "./roles.js";
+
+export interface AiModelRoleAssignment {
+    /** Empty string means the role is unfilled. */
+    connectionId: string;
+    /** Fully qualified, e.g. `"anthropic/claude-sonnet-4-5"`. Empty string means unfilled. */
+    model: string;
+}
+
+export type AiModelRoleAssignments = Record<AiModelRoleId, AiModelRoleAssignment>;
+
+declare module "~/api/types.js" {
+    interface IAiPowerUpsSettings {
+        modelRoles: {
+            roles: AiModelRoleAssignments;
+        };
+    }
+}
+
+export type ModelRolesSettings = IAiPowerUpsSettings["modelRoles"];
+
+export interface PersistedModelRoles {
+    roles?: Partial<Record<string, Partial<AiModelRoleAssignment>>>;
+}
+
+export const emptyAssignment = (): AiModelRoleAssignment => ({ connectionId: "", model: "" });

--- a/packages/ai-powerups/src/api/features/UpdateSettings/UpdateSettingsRepository.ts
+++ b/packages/ai-powerups/src/api/features/UpdateSettings/UpdateSettingsRepository.ts
@@ -31,7 +31,14 @@ class UpdateSettingsRepositoryImpl implements UpdateSettingsRepository.Interface
 
         const existingInternal: Record<string, unknown> = {};
         for (const handler of this.handlers) {
-            existingInternal[handler.name] = handler.mapFromStorage(raw[handler.name]);
+            /*
+             * `raw` matters here as much as it does on read. `connections` derives itself from the
+             * legacy `providers` section until it has one of its own, and this is what
+             * `mapToStorage` diffs against to carry forward an encrypted key the form only ever saw
+             * as a mask. Without it, the first save after an upgrade compares against an empty list
+             * and silently drops every stored key.
+             */
+            existingInternal[handler.name] = handler.mapFromStorage(raw[handler.name], raw);
         }
 
         const newSettings = input as unknown as Record<string, unknown>;
@@ -70,7 +77,7 @@ class UpdateSettingsRepositoryImpl implements UpdateSettingsRepository.Interface
 
         const result: Record<string, unknown> = {};
         for (const handler of this.handlers) {
-            result[handler.name] = handler.mapFromStorage(persisted[handler.name]);
+            result[handler.name] = handler.mapFromStorage(persisted[handler.name], persisted);
         }
 
         for (const key of Object.keys(persisted)) {

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
@@ -2,9 +2,12 @@ import { stepCountIs } from "ai";
 import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
 import { AiSdkTools } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { ListTagsUseCase } from "@webiny/api-file-manager/features/file/ListTags/index.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { WB_GENERATE_PAGE_CAPABILITY } from "./capability.js";
 import {
     AiPromptContextBuilder,
     formatAdditionalFilesContext
@@ -23,31 +26,21 @@ import { ComponentFilter } from "./ComponentFilter.js";
 class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.Interface {
     constructor(
         private promptContextBuilder: AiPromptContextBuilder.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
         private aiSdkTools: AiSdkTools.Interface,
-        private encryption: Encryption.Interface,
         private listTags: ListTagsUseCase.Interface
     ) {}
 
     async execute(
         params: WbGeneratePageContentParams
     ): Promise<Result<GeneratePageContentResult, Error>> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
-            return Result.fail(new Error("Failed to load AI PowerUps settings."));
+        const resolved = await this.resolveCapability.execute(WB_GENERATE_PAGE_CAPABILITY);
+        if (resolved.isFail()) {
+            return Result.fail(resolved.error);
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return Result.fail(
-                new Error("No AI provider configured. Add a provider in AI Power Ups settings.")
-            );
-        }
-
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
+        const capability = resolved.value;
 
         const sdkTools = this.aiSdkTools.getToolSet();
 
@@ -76,8 +69,10 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
         const imageTags = tagsResult.isOk() ? tagsResult.value.map(t => t.tag) : [];
 
         const components = params.components as Array<{ name: string }>;
-        const systemText =
-            buildDomainPrompt(components, params.tools, imageTags) + context.toString();
+        const systemText = withAdditionalInstructions(
+            buildDomainPrompt(components, params.tools, imageTags) + context.toString(),
+            capability
+        );
 
         const system = {
             role: "system" as const,
@@ -91,11 +86,8 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
 
         try {
             const aiResult = await this.ai.generateText({
-                model: firstProvider.model,
-                connection: {
-                    sdkName: firstProvider.model.split("/")[0],
-                    apiKey
-                },
+                model: capability.model,
+                connection: capability.connection,
                 system,
                 toolChoice: "auto",
                 prompt: params.prompt + formatAdditionalFilesContext(context.additionalFiles),
@@ -151,10 +143,9 @@ export const WbGeneratePageContentUseCaseImplementation =
         implementation: WbGeneratePageContentUseCaseImpl,
         dependencies: [
             AiPromptContextBuilder,
-            GetSettingsUseCase,
+            ResolveAiCapabilityUseCase,
             Ai,
             AiSdkTools,
-            Encryption,
             ListTagsUseCase
         ]
     });

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
@@ -70,8 +70,8 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
 
         const components = params.components as Array<{ name: string }>;
         const systemText = withAdditionalInstructions(
-            buildDomainPrompt(components, params.tools, imageTags) + context.toString(),
-            capability
+            capability,
+            buildDomainPrompt(components, params.tools, imageTags) + context.toString()
         );
 
         const system = {

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/capability.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/capability.ts
@@ -1,0 +1,20 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const WB_GENERATE_PAGE_CAPABILITY = "wb.generatePage";
+
+/**
+ * No `guidance`, for the same reason as CMS entry generation: the prompt carries the component
+ * catalog and the tool definitions, both computed per request.
+ */
+class WbGeneratePageCapabilityImpl implements AiCapability.Interface {
+    readonly id = WB_GENERATE_PAGE_CAPABILITY;
+    readonly label = "Page generation";
+    readonly description =
+        "Writes page content from a prompt using the Website Builder components available in the project.";
+    readonly defaultRole = "standard" as const;
+}
+
+export const WbGeneratePageCapability = AiCapability.createImplementation({
+    implementation: WbGeneratePageCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/feature.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/feature.ts
@@ -1,10 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { WbGeneratePageContentUseCaseImplementation } from "./WbGeneratePageContentUseCase.js";
 import { WbGeneratePageContentTask } from "./WbGeneratePageContentTask.js";
+import { WbGeneratePageCapability } from "./capability.js";
 
 export const WbGeneratePageContentFeature = createFeature({
     name: "AiPowerUps/WbGeneratePageContent",
     register(container) {
+        container.register(WbGeneratePageCapability);
         container.register(WbGeneratePageContentUseCaseImplementation);
         container.register(WbGeneratePageContentTask);
     }

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
@@ -115,7 +115,7 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         const result = await this.ai.generateText({
             model: capability.model,
             connection: capability.connection,
-            system: withAdditionalInstructions(capability.guidance, capability),
+            system: withAdditionalInstructions(capability),
             prompt: `Translate given key-value pairs from "${sourceLanguage}" to language code "${targetLanguage}". Do not modify the keys. "properties" is a simple key-value pair. "bindings" values are located in the "value" key. ${input}`,
             temperature: 0.3
         });

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
@@ -1,6 +1,7 @@
 import set from "lodash/set";
 import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import { GetDefaultLanguageUseCase } from "@webiny/languages/exports/api/languages.js";
 import { TranslatePageUseCase } from "@webiny/api-website-builder/features/pages/TranslatePage/index.js";
 import { UpdatePageRepository } from "@webiny/api-website-builder/features/pages/UpdatePage/abstractions.js";
@@ -37,6 +38,7 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         private getDefaultLanguage: GetDefaultLanguageUseCase.Interface,
         private getPageById: GetPageByIdUseCase.Interface,
         private resolveCapability: ResolveAiCapabilityUseCase.Interface,
+        private logger: Logger.Interface,
         private ai: Ai.Interface,
         private lexicalParser: LexicalParser.Interface,
         private updatePageRepository: UpdatePageRepository.Interface,
@@ -96,12 +98,7 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
              * the page is already created, just untranslated. It does get logged now, because a
              * silently skipped translation was indistinguishable from a misconfigured one.
              */
-            console.error(
-                JSON.stringify({
-                    message: "Skipping AI page translation.",
-                    reason: resolved.error.message
-                })
-            );
+            this.logger.warn({ reason: resolved.error.message }, "Skipping AI page translation.");
             return null;
         }
 
@@ -212,6 +209,7 @@ export const WbTranslatePageDecorator = TranslatePageUseCase.createDecorator({
         GetDefaultLanguageUseCase,
         GetPageByIdUseCase,
         ResolveAiCapabilityUseCase,
+        Logger,
         Ai,
         LexicalParser,
         UpdatePageRepository

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/WbTranslatePageDecorator.ts
@@ -1,12 +1,15 @@
 import set from "lodash/set";
 import { Result } from "@webiny/feature/api";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
-import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { GetDefaultLanguageUseCase } from "@webiny/languages/exports/api/languages.js";
 import { TranslatePageUseCase } from "@webiny/api-website-builder/features/pages/TranslatePage/index.js";
 import { UpdatePageRepository } from "@webiny/api-website-builder/features/pages/UpdatePage/abstractions.js";
 import type { WbPage } from "@webiny/api-website-builder/domain/page/abstractions.js";
-import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
+import {
+    ResolveAiCapabilityUseCase,
+    withAdditionalInstructions
+} from "~/api/features/Capabilities/index.js";
+import { WB_TRANSLATE_PAGE_CAPABILITY } from "./capability.js";
 import { LexicalParser } from "./abstractions/LexicalParser.js";
 import { GetPageByIdUseCase } from "@webiny/api-website-builder/exports/api/website-builder/page.js";
 import { LlmJsonResponse } from "~/domain/LlmJsonResponse.js";
@@ -33,9 +36,8 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
     constructor(
         private getDefaultLanguage: GetDefaultLanguageUseCase.Interface,
         private getPageById: GetPageByIdUseCase.Interface,
-        private getSettings: GetSettingsUseCase.Interface,
+        private resolveCapability: ResolveAiCapabilityUseCase.Interface,
         private ai: Ai.Interface,
-        private encryption: Encryption.Interface,
         private lexicalParser: LexicalParser.Interface,
         private updatePageRepository: UpdatePageRepository.Interface,
         private decoratee: TranslatePageUseCase.Interface
@@ -87,19 +89,23 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         sourceLanguage: string,
         targetLanguage: string
     ): Promise<TranslatedData | null> {
-        const settingsResult = await this.getSettings.execute();
-        if (settingsResult.isFail()) {
+        const resolved = await this.resolveCapability.execute(WB_TRANSLATE_PAGE_CAPABILITY);
+        if (resolved.isFail()) {
+            /*
+             * Translation is a decorator on top of a successful page save, so it stays non-fatal:
+             * the page is already created, just untranslated. It does get logged now, because a
+             * silently skipped translation was indistinguishable from a misconfigured one.
+             */
+            console.error(
+                JSON.stringify({
+                    message: "Skipping AI page translation.",
+                    reason: resolved.error.message
+                })
+            );
             return null;
         }
 
-        const settings = settingsResult.value;
-        const firstProvider = settings.providers.presets[0];
-
-        if (!firstProvider) {
-            return null;
-        }
-
-        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
+        const capability = resolved.value;
 
         const properties = {
             title: page.properties["title"],
@@ -110,12 +116,9 @@ class WbTranslatePageDecoratorImpl implements TranslatePageUseCase.Interface {
         const input = JSON.stringify({ properties, bindings });
 
         const result = await this.ai.generateText({
-            model: firstProvider.model,
-            connection: {
-                sdkName: firstProvider.model.split("/")[0],
-                apiKey
-            },
-            system: `You are a professional translator. Translate all user-provided text to language code "${targetLanguage}", preserving placeholders and formatting. Return a JSON object with the same keys, only changing the values.`,
+            model: capability.model,
+            connection: capability.connection,
+            system: withAdditionalInstructions(capability.guidance, capability),
             prompt: `Translate given key-value pairs from "${sourceLanguage}" to language code "${targetLanguage}". Do not modify the keys. "properties" is a simple key-value pair. "bindings" values are located in the "value" key. ${input}`,
             temperature: 0.3
         });
@@ -208,9 +211,8 @@ export const WbTranslatePageDecorator = TranslatePageUseCase.createDecorator({
     dependencies: [
         GetDefaultLanguageUseCase,
         GetPageByIdUseCase,
-        GetSettingsUseCase,
+        ResolveAiCapabilityUseCase,
         Ai,
-        Encryption,
         LexicalParser,
         UpdatePageRepository
     ]

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/capability.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/capability.ts
@@ -1,0 +1,26 @@
+import { AiCapability } from "~/api/features/Capabilities/index.js";
+
+export const WB_TRANSLATE_PAGE_CAPABILITY = "wb.translatePage";
+
+/**
+ * The target language used to be interpolated into this sentence. It moved to the user prompt so
+ * the instructions could become fixed text a project can replace, which is worth doing here: house
+ * translation rules (keep product names in English, use formal address, never translate these
+ * twelve terms) are the most commonly requested prompt change in the whole feature set.
+ */
+const guidance =
+    "You are a professional translator. Translate all user-provided text to the requested target language, preserving placeholders and formatting. Return a JSON object with the same keys, only changing the values.";
+
+class WbTranslatePageCapabilityImpl implements AiCapability.Interface {
+    readonly id = WB_TRANSLATE_PAGE_CAPABILITY;
+    readonly label = "Page translation";
+    readonly description =
+        "Translates the text on a page into another language, preserving placeholders.";
+    readonly defaultRole = "standard" as const;
+    readonly guidance = guidance;
+}
+
+export const WbTranslatePageCapability = AiCapability.createImplementation({
+    implementation: WbTranslatePageCapabilityImpl,
+    dependencies: []
+});

--- a/packages/ai-powerups/src/api/features/WbTranslatePage/feature.ts
+++ b/packages/ai-powerups/src/api/features/WbTranslatePage/feature.ts
@@ -1,11 +1,13 @@
 import { createFeature } from "@webiny/feature/api";
 import { WbTranslatePageDecorator } from "./WbTranslatePageDecorator.js";
+import { WbTranslatePageCapability } from "./capability.js";
 import { LexicalParser } from "./LexicalParser.js";
 
 export const WbTranslatePageFeature = createFeature({
     name: "AiPowerUps/WbTranslatePage",
     register(container) {
         container.register(LexicalParser).inSingletonScope();
+        container.register(WbTranslatePageCapability);
         container.registerDecorator(WbTranslatePageDecorator);
     }
 });

--- a/packages/ai-powerups/src/api/features/shared/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/shared/abstractions.ts
@@ -4,7 +4,12 @@ import type { ZodType } from "zod";
 export interface IAiPowerUpsSettingsGroupHandler {
     readonly name: string;
     readonly inputSchema: ZodType<unknown>;
-    mapFromStorage(persisted: unknown): unknown;
+    /**
+     * `all` is the entire persisted settings blob. A group only needs it to read a section it does
+     * not own, which in practice means migrating away from one: `connections` and `modelRoles` both
+     * derive their defaults from the legacy `providers` section the first time they load.
+     */
+    mapFromStorage(persisted: unknown, all?: Record<string, unknown>): unknown;
     mapToStorage(internal: unknown, existing: unknown | null): Promise<unknown>;
 }
 

--- a/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
+++ b/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
@@ -5,6 +5,7 @@ import { TaskService } from "@webiny/api-core/features/task/TaskService/index.js
 import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
 import { UpdateSettingsUseCase } from "~/api/features/UpdateSettings/index.js";
+import { AiCapability } from "~/api/features/Capabilities/index.js";
 import { AiPowerUpsSettingsGraphQLMapper } from "./abstractions.js";
 import {
     WB_GENERATE_PAGE_CONTENT_TASK_ID,
@@ -29,8 +30,16 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
                 endOfLife: Date
             }
 
+            type AiCapability {
+                id: String!
+                label: String!
+                description: String!
+                defaultRole: String!
+            }
+
             type AiPowerUpsQuery {
                 listModels: [AiModel!]!
+                listCapabilities: [AiCapability!]!
                 getSettings: JSON
             }
 
@@ -93,6 +102,25 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
             dependencies: [AiModelRegistry],
             resolver: (registry: AiModelRegistry.Interface) => {
                 return async () => registry.listModels();
+            }
+        });
+
+        /*
+         * Read straight off the container's registered capabilities. The admin screen has no list
+         * of its own, so a feature that registers a capability gets a settings row without touching
+         * the admin app.
+         */
+        builder.addResolver({
+            path: "AiPowerUpsQuery.listCapabilities",
+            dependencies: [[AiCapability, { multiple: true }]],
+            resolver: (capabilities: AiCapability.Interface[]) => {
+                return async () =>
+                    capabilities.map(c => ({
+                        id: c.id,
+                        label: c.label,
+                        description: c.description,
+                        defaultRole: c.defaultRole
+                    }));
             }
         });
 

--- a/packages/ai-powerups/src/api/types.ts
+++ b/packages/ai-powerups/src/api/types.ts
@@ -1,4 +1,7 @@
 import "@webiny/background-tasks/api/features/TaskController/augmentation.js";
+import "~/api/features/Connections/types.js";
+import "~/api/features/ModelRoles/types.js";
+import "~/api/features/Capabilities/types.js";
 import "~/api/features/Providers/types.js";
 import "~/api/features/Projects/types.js";
 

--- a/packages/handler-graphql/__tests__/GraphQLSchemaBuilder.test.ts
+++ b/packages/handler-graphql/__tests__/GraphQLSchemaBuilder.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { Container } from "@webiny/di";
+import { createAbstraction } from "@webiny/feature/api";
+import { GraphQLSchemaBuilder } from "~/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.js";
+
+interface IGreeter {
+    greet(): string;
+}
+
+const Greeter = createAbstraction<IGreeter>("TestGreeter");
+
+class Hello implements IGreeter {
+    greet() {
+        return "hello";
+    }
+}
+
+class Goodbye implements IGreeter {
+    greet() {
+        return "goodbye";
+    }
+}
+
+/**
+ * `addResolver` resolves its dependencies off the request container at call time, so the resolver
+ * has to be invoked through the built resolver map to see what it actually received.
+ */
+function callResolver(builder: GraphQLSchemaBuilder.Interface, path: string, container: Container) {
+    const schema = builder.build();
+    const [type, field] = path.split(".");
+    const resolver = (schema.resolvers as Record<string, Record<string, any>>)[type][field];
+
+    return resolver({}, {}, { container }, {});
+}
+
+describe("GraphQLSchemaBuilder resolver dependencies", () => {
+    it("single-resolves a bare abstraction", async () => {
+        const container = new Container();
+        container.register(
+            Greeter.createImplementation({ implementation: Hello, dependencies: [] })
+        );
+
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greeting: String
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greeting",
+            dependencies: [Greeter],
+            resolver: (greeter: IGreeter) => () => greeter.greet()
+        });
+
+        expect(await callResolver(builder, "Query.greeting", container)).toBe("hello");
+    });
+
+    /*
+     * The regression this file exists for. `addResolver` accepted the `[abstraction, options]`
+     * dependency tuple, destructured it, dropped the options and single-resolved anyway, so a
+     * resolver asking for every implementation got one object and died on `.map`. It surfaced as
+     * "e.map is not a function" from the resolver, with nothing pointing at the builder.
+     */
+    it("resolves every implementation when a dependency asks for multiple", async () => {
+        const container = new Container();
+        container.register(
+            Greeter.createImplementation({ implementation: Hello, dependencies: [] })
+        );
+        container.register(
+            Greeter.createImplementation({ implementation: Goodbye, dependencies: [] })
+        );
+
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greetings: [String]
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greetings",
+            dependencies: [[Greeter, { multiple: true }]],
+            resolver: (greeters: IGreeter[]) => () => greeters.map(g => g.greet())
+        });
+
+        const result = await callResolver(builder, "Query.greetings", container);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toEqual(expect.arrayContaining(["hello", "goodbye"]));
+    });
+
+    it("returns an array, not undefined, when nothing is registered for a multiple dependency", async () => {
+        const builder = new GraphQLSchemaBuilder();
+        builder.addTypeDefs(/* GraphQL */ `
+            type Query {
+                greetings: [String]
+            }
+        `);
+        builder.addResolver({
+            path: "Query.greetings",
+            dependencies: [[Greeter, { multiple: true }]],
+            resolver: (greeters: IGreeter[]) => () => greeters.map(g => g.greet())
+        });
+
+        expect(await callResolver(builder, "Query.greetings", new Container())).toEqual([]);
+    });
+});

--- a/packages/handler-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
+++ b/packages/handler-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
@@ -20,8 +20,17 @@ export class GraphQLSchemaBuilder implements Abstraction.Interface {
 
         const graphqlResolver = (parent: any, args: TArgs, context: any, info: any) => {
             const resolvedDeps = dependencies.map((dep: Dependency) => {
-                const [abstraction] = Array.isArray(dep) ? dep : [dep];
-                return context.container.resolve(abstraction);
+                /*
+                 * `Dependency` allows `[abstraction, { multiple: true }]`, same as anywhere else in
+                 * the container. This used to destructure the tuple, throw the options away and
+                 * always single-resolve, so a resolver asking for every implementation of an
+                 * abstraction received one object and failed on `.map`.
+                 */
+                const [abstraction, options] = Array.isArray(dep) ? dep : [dep, undefined];
+
+                return options?.multiple
+                    ? context.container.resolveAll(abstraction)
+                    : context.container.resolve(abstraction);
             });
 
             const actualResolver = resolver(...resolvedDeps);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10528,6 +10528,7 @@ __metadata:
     "@webiny/app-websockets": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler-aws": "npm:0.0.0"
     "@webiny/handler-graphql": "npm:0.0.0"


### PR DESCRIPTION
Ships in 6.5.0. A `next` counterpart exists as a draft (#5691) and will be reconciled after this lands, since `release/6.5.0` merges forward into `next`.

> [!NOTE]
> **No longer depends on #5698.** `listCapabilities` used to be the one `addResolver` call using the `[abstraction, { multiple: true }]` dependency form, which `handler-graphql` ignores. It now goes through `ListAiCapabilitiesUseCase`, which takes that dependency via `createImplementation` where it has always worked. #5698 is still a real bug worth fixing, but the two PRs are independent and can merge in either order.

## What

Every AI feature read `providers.presets[0]`, with the same lines copy-pasted into five places: re-deriving the SDK name from the model string and decrypting the key each time. So "which model runs this feature" had five answers that only happened to agree. The settings screen was never finished; picking the first model was the placeholder that shipped.

This replaces it with three layers and one resolver.

**Connections** are a vendor and a credential, no model. The section they replace welded a key to a single model, so two Anthropic models meant pasting the same key twice.

**Model roles** are the indirection between a feature and a model: `fast`, `standard`, `vision`. A feature names a role, the project decides which model fills it. For most projects this is the whole AI configuration. `vision` exists because image enrichment needs a capability, not a price tier.

**Capabilities** are the per-feature exceptions, all empty by default. Features register their own next to their own code, so the settings screen has no list to maintain and an extension that adds an AI feature gets a settings row for free.

`ResolveAiCapabilityUseCase` is the only place that knows the precedence rules: a pinned connection and model, else the chosen role, else the declared default role, else `standard`. No environment-variable fallback; settings saying one thing while requests use another is the confusion this replaces.

## Prompts are append-only

There is no "replace the prompt" option, deliberately. For most capabilities the prompt carries the output contract the surrounding code parses. Revision comparison regex-matches the HTML table its prompt specifies, including the literal "No differences detected" sentence and a `<tr>` count. Page translation specifies a JSON shape and then parses it, handing back the untranslated page when that fails. Replacing either means replacing part of the implementation, with silence as the failure mode.

`additionalInstructions` appends instead, so the contract stays in the prompt. Projects needing different behaviour decorate the use case in code, which is how the AI translation itself is built.

## Upgrades

`connections` and `modelRoles` seed themselves from the legacy `providers` section on first read: each preset becomes a connection, and preset 0's model becomes `standard`. Since preset 0 is the only model the old code ever used, this reproduces current behaviour exactly. Keys are already encrypted, so it is a pure read. An unfilled role falls back to `standard` for the same reason.

`providers` still round-trips through storage so seeding keeps working. It goes away with the next breaking release.

## Incidental fixes

- `UpdateSettingsRepository` built its "existing" snapshot without the full settings blob. Since `connections` derives itself from `providers` until it has its own section, and that snapshot is what `mapToStorage` diffs against to recognise a masked key, the first save after an upgrade would have **silently destroyed the project's stored API key**.
- The AI buttons tested `presets.length > 0`, which passes for a row with no key in it, so the button rendered and the request then failed. They now check the whole chain the api walks.
- A skipped page translation was indistinguishable from a misconfigured one; it logs the reason now.

## Deliberate difference from the `next` version

**Image enrichment keeps its soft skip.** On `next` a missing model fails the enrichment task. That is safe there because the feature is licence-gated and unconfigured projects never register it. There is no such gate on this branch, so erroring would fail a task on every image upload for any project without AI configured. It logs the reason and returns `done`, which is this branch's current behaviour plus a reason in the log.

The enrichment prompt also moved from `AiImageEnrichmentTask` into the capability declaration, since that is where the resolver reads it from. The task's image-by-URL handling is unchanged.

## Testing

40 tests in `ai-powerups`, green. `adio`, `format` and `lint` clean.

Design doc, with screenshots of each tab and the open decisions: https://app.notion.com/p/3d5523905585811885aac3da4c3eee52

Note that the screenshots there were taken against the `next` build, so the Connections vendor list shows two vendors. This branch also has a `GoogleSdkFactory`, so it will show three.

