### PR TITLE
fix(api-event-handler-aws): give the streaming handler a task dispatcher

### DIFF
--- a/packages/api-event-handler-aws/src/createWebinyStreamApiHandler.ts
+++ b/packages/api-event-handler-aws/src/createWebinyStreamApiHandler.ts
@@ -8,14 +8,20 @@
  * stream at all.
  *
  * Root/request registration is shared with `createWebinyApiHandler` via `composition/`; only
- * the transport differs. Notably NOT registered here: the background-task and WebSocket event types
- * plus their Lambda handlers. Those are inbound invocation paths that only ever target the buffered
- * function, so registering them would add cold-start cost for events this function never receives.
- * The websockets *outbound* transport IS present — it comes from the shared per-request stack, and
- * streaming routes rely on it to push completion messages.
+ * the transport differs. Notably NOT registered here: the background-task and WebSocket **event
+ * types**. Those match inbound invocations that only ever target the buffered function, so
+ * registering them would add cold-start cost for events this function never receives.
+ *
+ * Outbound transports are a different matter, and both ARE present: websockets push completion
+ * messages from the shared per-request stack, and `BackgroundTasksAwsFeature` supplies the Step
+ * Functions dispatcher that `TaskService.trigger()` needs. Omitting the latter does not disable
+ * task triggering — it breaks it silently, because the shared root registers `TaskService` either
+ * way and its callers treat a failed trigger as a no-op (ACO's FLP handlers, for one, swallow it),
+ * so writes land while their projections never update.
  */
 import { getDocumentClient } from "@webiny/aws-sdk/client-dynamodb/index.js";
 import { createStreamLambdaHandler, FunctionUrlStreamFeature } from "@webiny/event-handler-aws";
+import { BackgroundTasksAwsFeature } from "@webiny/background-tasks-aws";
 import { FunctionUrlStreamIdentityLoaderDecorator } from "~/handlers/FunctionUrlStreamIdentityLoaderDecorator.js";
 import { FunctionUrlStreamTenantLoaderDecorator } from "~/handlers/FunctionUrlStreamTenantLoaderDecorator.js";
 import { registerWebinyApiChild, registerWebinyApiRoot } from "~/composition/index.js";
@@ -41,6 +47,14 @@ export function createWebinyStreamApiHandler(config: CreateWebinyStreamApiHandle
             // the buffered handler.
             container.registerDecorator(FunctionUrlStreamIdentityLoaderDecorator);
             container.registerDecorator(FunctionUrlStreamTenantLoaderDecorator);
+
+            // ── Background tasks: outbound dispatch only ───────────────
+            // Registers StepFunctionService, which is what a `TaskService.trigger()` resolves to
+            // actually start an execution. Without it the trigger throws deep inside the container
+            // and every caller that ignores the failure just carries on. `BackgroundTaskEventType`
+            // is deliberately left out, so the handler this also registers stays unreachable here:
+            // Step Functions invokes the buffered function, never this one.
+            BackgroundTasksAwsFeature.register(container);
 
             // Resolved here rather than at factory time: one bundle exports BOTH this handler and the
             // buffered one, so building the client eagerly would open a second DynamoDB client on every


### PR DESCRIPTION
A write served by a `/stream/*` route commits, and anything that write was supposed to schedule never
happens. Nothing errors, so it reads as the write having silently done nothing.

## The chain

`createWebinyStreamApiHandler` skipped `BackgroundTasksAwsFeature`, on the reasoning that
background-task invocations only ever target the buffered function. That is true of the event
**type**. It is not true of the rest of the feature:

```ts
register(container) {
    container.register(BackgroundTaskLambdaHandler);   // inbound, correctly irrelevant here
    container.register(StepFunctionService);           // OUTBOUND dispatcher, needed here
}
```

`StepFunctionService` is what a `TaskService.trigger()` resolves to in order to start an execution.

The shared root registers `TaskService` regardless of transport, so in the streaming function a
caller **finds** it, calls `trigger()`, and resolution fails on the missing dispatcher. Nothing about
that is visible at the call site.

## Why it stays silent

`trigger()` returns a `Result`, so a failure is not thrown, and callers that treat a failed trigger
as a no-op carry on. ACO's FLP handlers do exactly that, in all three of create, update and delete:

```ts
try {
    if (this.tasks) {
        await this.tasks.trigger({ definition: UPDATE_FLP_TASK_ID, input: { folder } });
    } else {
        await this.updateFlpUseCase.execute({ folder });
    }
} catch {
    // Ignore errors
}
```

## What that looked like

Folder permissions live in two places. The write lands on the folder's CMS entry; a task projects it
onto the folder's FLP record. **Folder reads report the FLP record, not the entry.**

So a permission change through a streaming route updated the entry and left every reader seeing the
old permissions. Confirmed against a real deployment by reading both stores directly:

```
CMS entry   values.object@permissions = []                    ← the write landed
FLP record  permissions = [{team:marketing-team, viewer}]     ← stale, and this is what reads return
```

and no `acoUpdateFlp` Step Functions execution at that write's timestamp, while the same change made
through the GraphQL mutation produced one every time.

## The fix

Register the feature for its dispatcher. `BackgroundTaskEventType` is still deliberately left out, so
the inbound handler the feature also registers stays unreachable here and Step Functions keeps
invoking only the buffered function.

## Scope

Affects **every** streaming route, not one feature. Today `/stream/*` carries the File Manager
re-enrich route and the AI chat routes; any write they schedule was being dropped. Split out of
#5589, where it was found.

## Worth a separate look

The `catch {}` in ACO's three FLP handlers is what turned a missing registration into a silent data
inconsistency, and `trigger()` returning a `Result` that nobody checks is the other half. Not changed
here, because that is a behaviour change in ACO rather than a wiring fix, but it will hide the next
one too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
